### PR TITLE
✨ Add keyboard controls to fullscreen player

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -28,6 +28,11 @@ final router = GoRouter(
           channelLogo: extra['channelLogo'] as String?,
           alternativeUrls:
               (extra['alternativeUrls'] as List<String>?) ?? const [],
+          channels:
+              (extra['channels'] as List<dynamic>?)
+                  ?.cast<Map<String, dynamic>>() ??
+              const [],
+          currentIndex: extra['currentIndex'] as int? ?? 0,
         );
       },
     ),


### PR DESCRIPTION
Adds keyboard navigation to the fullscreen player screen:

- **ESC / Backspace**: Exit fullscreen (with visible ESC badge hint)
- **Up / Down arrows**: Switch channels (wraps around, updates display + stream)
- **Left / Right arrows**: Volume control (±5, overlay shows level for 1.5s)

Changes:
- `channels_screen.dart`: Pass filtered channel list + index via route extras
- `router.dart`: Extract and forward `channels` / `currentIndex` to PlayerScreen
- `player_screen.dart`: Focus widget with onKeyEvent, volume overlay, channel switching, ESC hint