### PR TITLE
🐛 fix: audio race condition and guide row overflow

### DIFF
--- a/lib/features/channels/channels_screen.dart
+++ b/lib/features/channels/channels_screen.dart
@@ -2229,6 +2229,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         final now = DateTime.now();
 
         return Row(
+          mainAxisSize: MainAxisSize.min,
           children: programmes.map((prog) {
             final durationMin =
                 prog.stop.difference(prog.start).inMinutes.clamp(1, 1440);


### PR DESCRIPTION
- Await player init before playback to ensure eac3/ac3 mpv properties are set
- Exclude AudioToolbox hardware decoders (-eac3_at,-ac3_at) that silently fail
- Fix guide programme Row overflow (mainAxisSize: min)