### PR TITLE
✨ Add Shows & Movies integration with Trakt, TMDB, Real-Debrid

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -6,6 +6,9 @@ import '../features/player/player_screen.dart';
 import '../features/providers/providers_screen.dart';
 import '../features/epg_mapping/epg_mapping_screen.dart';
 import '../features/settings/settings_screen.dart';
+import '../features/shows/shows_screen.dart';
+import '../features/shows/show_detail_screen.dart';
+import '../data/models/show.dart';
 
 final router = GoRouter(
   initialLocation: '/',
@@ -47,6 +50,18 @@ final router = GoRouter(
     GoRoute(
       path: '/settings',
       builder: (context, state) => const SettingsScreen(),
+    ),
+    GoRoute(
+      path: '/shows',
+      builder: (context, state) => const ShowsScreen(),
+    ),
+    GoRoute(
+      path: '/shows/:id',
+      builder: (context, state) {
+        final traktId = int.tryParse(state.pathParameters['id'] ?? '') ?? 0;
+        final show = state.extra as Show?;
+        return ShowDetailScreen(traktId: traktId, initialShow: show);
+      },
     ),
   ],
 );

--- a/lib/data/datasources/remote/debrid_client.dart
+++ b/lib/data/datasources/remote/debrid_client.dart
@@ -1,0 +1,193 @@
+import 'package:dio/dio.dart';
+import '../../models/show.dart';
+
+/// Client for Real-Debrid API v1.0
+/// Docs: https://api.real-debrid.com/
+class DebridClient {
+  final Dio _dio;
+  final String apiToken;
+
+  static const _baseUrl = 'https://api.real-debrid.com/rest/1.0';
+
+  DebridClient({
+    required this.apiToken,
+    Dio? dio,
+  }) : _dio = dio ?? Dio() {
+    _dio.options
+      ..baseUrl = _baseUrl
+      ..connectTimeout = const Duration(seconds: 10)
+      ..receiveTimeout = const Duration(seconds: 30)
+      ..headers = {
+        'Authorization': 'Bearer $apiToken',
+      };
+  }
+
+  /// Check if torrent hashes are instantly available (cached)
+  /// Returns a map of hash → list of available file variants
+  Future<Map<String, List<DebridFile>>> checkInstantAvailability(
+    List<String> hashes,
+  ) async {
+    if (hashes.isEmpty) return {};
+
+    final hashStr = hashes.join('/');
+    final response = await _dio.get('/torrents/instantAvailability/$hashStr');
+    final data = response.data as Map<String, dynamic>;
+
+    final result = <String, List<DebridFile>>{};
+    for (final hash in hashes) {
+      final hashLower = hash.toLowerCase();
+      if (data.containsKey(hashLower)) {
+        final hostData = data[hashLower] as Map<String, dynamic>;
+        final files = <DebridFile>[];
+        for (final host in hostData.values) {
+          if (host is List) {
+            for (final variant in host) {
+              if (variant is Map<String, dynamic>) {
+                for (final entry in variant.entries) {
+                  final fileInfo = entry.value as Map<String, dynamic>;
+                  files.add(DebridFile(
+                    id: int.tryParse(entry.key) ?? 0,
+                    filename: fileInfo['filename'] as String? ?? '',
+                    filesize: fileInfo['filesize'] as int? ?? 0,
+                  ));
+                }
+              }
+            }
+          }
+        }
+        if (files.isNotEmpty) {
+          result[hashLower] = files;
+        }
+      }
+    }
+    return result;
+  }
+
+  /// Add a magnet link and return the torrent ID
+  Future<String> addMagnet(String magnetLink) async {
+    final response = await _dio.post(
+      '/torrents/addMagnet',
+      data: FormData.fromMap({'magnet': magnetLink}),
+    );
+    return response.data['id'] as String;
+  }
+
+  /// Select files from a torrent for downloading
+  Future<void> selectFiles(String torrentId, {String files = 'all'}) async {
+    await _dio.post(
+      '/torrents/selectFiles/$torrentId',
+      data: FormData.fromMap({'files': files}),
+    );
+  }
+
+  /// Get torrent info including download links
+  Future<DebridTorrentInfo> getTorrentInfo(String torrentId) async {
+    final response = await _dio.get('/torrents/info/$torrentId');
+    return DebridTorrentInfo.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  /// Unrestrict a link to get a direct download/stream URL
+  Future<ResolvedStream> unrestrictLink(String link) async {
+    final response = await _dio.post(
+      '/unrestrict/link',
+      data: FormData.fromMap({'link': link}),
+    );
+    final data = response.data as Map<String, dynamic>;
+    return ResolvedStream(
+      url: data['download'] as String,
+      filename: data['filename'] as String? ?? 'unknown',
+      filesize: data['filesize'] as int?,
+      source: 'real-debrid',
+    );
+  }
+
+  /// Full flow: add magnet → select files → wait → get stream URL
+  Future<ResolvedStream?> resolveFromMagnet(String magnetLink) async {
+    final torrentId = await addMagnet(magnetLink);
+    await selectFiles(torrentId);
+
+    // Poll until ready (max 30 seconds)
+    for (var i = 0; i < 15; i++) {
+      await Future.delayed(const Duration(seconds: 2));
+      final info = await getTorrentInfo(torrentId);
+      if (info.status == 'downloaded' && info.links.isNotEmpty) {
+        return unrestrictLink(info.links.first);
+      }
+      if (info.status == 'error' || info.status == 'dead') {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  /// Delete a torrent from the user's list
+  Future<void> deleteTorrent(String torrentId) async {
+    await _dio.delete('/torrents/delete/$torrentId');
+  }
+
+  /// Get user account info (to verify API token)
+  Future<bool> verifyToken() async {
+    try {
+      await _dio.get('/user');
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+}
+
+/// A file within a cached torrent
+class DebridFile {
+  final int id;
+  final String filename;
+  final int filesize;
+
+  const DebridFile({
+    required this.id,
+    required this.filename,
+    required this.filesize,
+  });
+
+  String get quality {
+    final lower = filename.toLowerCase();
+    if (lower.contains('2160p') || lower.contains('4k')) return '4K';
+    if (lower.contains('1080p')) return '1080p';
+    if (lower.contains('720p')) return '720p';
+    if (lower.contains('480p')) return '480p';
+    return 'Unknown';
+  }
+
+  String get filesizeDisplay {
+    final gb = filesize / (1024 * 1024 * 1024);
+    if (gb >= 1) return '${gb.toStringAsFixed(1)} GB';
+    final mb = filesize / (1024 * 1024);
+    return '${mb.toStringAsFixed(0)} MB';
+  }
+}
+
+/// Torrent info from Real-Debrid
+class DebridTorrentInfo {
+  final String id;
+  final String filename;
+  final String status;
+  final int progress;
+  final List<String> links;
+
+  const DebridTorrentInfo({
+    required this.id,
+    required this.filename,
+    required this.status,
+    required this.progress,
+    this.links = const [],
+  });
+
+  factory DebridTorrentInfo.fromJson(Map<String, dynamic> json) {
+    return DebridTorrentInfo(
+      id: json['id'] as String,
+      filename: json['filename'] as String? ?? '',
+      status: json['status'] as String? ?? 'unknown',
+      progress: json['progress'] as int? ?? 0,
+      links: (json['links'] as List?)?.cast<String>() ?? [],
+    );
+  }
+}

--- a/lib/data/datasources/remote/tmdb_client.dart
+++ b/lib/data/datasources/remote/tmdb_client.dart
@@ -1,0 +1,231 @@
+import 'package:dio/dio.dart';
+
+/// Client for The Movie Database (TMDB) API v3
+/// Docs: https://developer.themoviedb.org/docs
+class TmdbClient {
+  final Dio _dio;
+  final String apiKey;
+
+  static const _baseUrl = 'https://api.themoviedb.org/3';
+  static const _imageBase = 'https://image.tmdb.org/t/p';
+
+  TmdbClient({
+    required this.apiKey,
+    Dio? dio,
+  }) : _dio = dio ?? Dio() {
+    _dio.options
+      ..baseUrl = _baseUrl
+      ..connectTimeout = const Duration(seconds: 10)
+      ..receiveTimeout = const Duration(seconds: 15)
+      ..queryParameters = {'api_key': apiKey};
+  }
+
+  /// Build a full image URL from a TMDB file path
+  static String imageUrl(String? path, {String size = 'w500'}) {
+    if (path == null || path.isEmpty) return '';
+    return '$_imageBase/$size$path';
+  }
+
+  /// Get poster URL (w500)
+  static String posterUrl(String? path) => imageUrl(path, size: 'w500');
+
+  /// Get backdrop URL (w1280)
+  static String backdropUrl(String? path) => imageUrl(path, size: 'w1280');
+
+  /// Get still/screenshot URL (w300)
+  static String stillUrl(String? path) => imageUrl(path, size: 'w300');
+
+  /// Get TV show details including images
+  Future<TmdbShowDetail> getTvShow(int tmdbId) async {
+    final response = await _dio.get('/tv/$tmdbId');
+    return TmdbShowDetail.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  /// Get movie details including images
+  Future<TmdbShowDetail> getMovie(int tmdbId) async {
+    final response = await _dio.get('/movie/$tmdbId');
+    return TmdbShowDetail.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  /// Get TV season details with episode list
+  Future<TmdbSeasonDetail> getTvSeason(int tmdbId, int seasonNumber) async {
+    final response = await _dio.get('/tv/$tmdbId/season/$seasonNumber');
+    return TmdbSeasonDetail.fromJson(response.data as Map<String, dynamic>);
+  }
+
+  /// Search for TV shows
+  Future<List<TmdbSearchResult>> searchTv(String query) async {
+    final response = await _dio.get(
+      '/search/tv',
+      queryParameters: {'query': query},
+    );
+    final results = response.data['results'] as List;
+    return results
+        .map((e) => TmdbSearchResult.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Search for movies
+  Future<List<TmdbSearchResult>> searchMovie(String query) async {
+    final response = await _dio.get(
+      '/search/movie',
+      queryParameters: {'query': query},
+    );
+    final results = response.data['results'] as List;
+    return results
+        .map((e) => TmdbSearchResult.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Find by external ID (e.g., IMDB ID)
+  Future<TmdbShowDetail?> findByImdbId(String imdbId, {bool isMovie = false}) async {
+    final response = await _dio.get(
+      '/find/$imdbId',
+      queryParameters: {'external_source': 'imdb_id'},
+    );
+    final key = isMovie ? 'movie_results' : 'tv_results';
+    final results = response.data[key] as List;
+    if (results.isEmpty) return null;
+    return TmdbShowDetail.fromJson(results.first as Map<String, dynamic>);
+  }
+}
+
+/// TMDB show/movie detail with image paths
+class TmdbShowDetail {
+  final int id;
+  final String? posterPath;
+  final String? backdropPath;
+  final String? overview;
+  final double? voteAverage;
+  final int? voteCount;
+  final List<String> genres;
+  final int? numberOfSeasons;
+  final int? numberOfEpisodes;
+
+  const TmdbShowDetail({
+    required this.id,
+    this.posterPath,
+    this.backdropPath,
+    this.overview,
+    this.voteAverage,
+    this.voteCount,
+    this.genres = const [],
+    this.numberOfSeasons,
+    this.numberOfEpisodes,
+  });
+
+  String get posterUrl => TmdbClient.posterUrl(posterPath);
+  String get backdropUrl => TmdbClient.backdropUrl(backdropPath);
+
+  factory TmdbShowDetail.fromJson(Map<String, dynamic> json) {
+    return TmdbShowDetail(
+      id: json['id'] as int,
+      posterPath: json['poster_path'] as String?,
+      backdropPath: json['backdrop_path'] as String?,
+      overview: json['overview'] as String?,
+      voteAverage: (json['vote_average'] as num?)?.toDouble(),
+      voteCount: json['vote_count'] as int?,
+      genres: (json['genres'] as List?)
+              ?.map((g) => (g as Map<String, dynamic>)['name'] as String)
+              .toList() ??
+          [],
+      numberOfSeasons: json['number_of_seasons'] as int?,
+      numberOfEpisodes: json['number_of_episodes'] as int?,
+    );
+  }
+}
+
+/// TMDB season detail with episodes
+class TmdbSeasonDetail {
+  final int seasonNumber;
+  final String? posterPath;
+  final String? overview;
+  final List<TmdbEpisode> episodes;
+
+  const TmdbSeasonDetail({
+    required this.seasonNumber,
+    this.posterPath,
+    this.overview,
+    this.episodes = const [],
+  });
+
+  factory TmdbSeasonDetail.fromJson(Map<String, dynamic> json) {
+    return TmdbSeasonDetail(
+      seasonNumber: json['season_number'] as int,
+      posterPath: json['poster_path'] as String?,
+      overview: json['overview'] as String?,
+      episodes: (json['episodes'] as List?)
+              ?.map((e) => TmdbEpisode.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+    );
+  }
+}
+
+/// A single TMDB episode
+class TmdbEpisode {
+  final int episodeNumber;
+  final int seasonNumber;
+  final String? name;
+  final String? overview;
+  final String? stillPath;
+  final double? voteAverage;
+  final String? airDate;
+
+  const TmdbEpisode({
+    required this.episodeNumber,
+    required this.seasonNumber,
+    this.name,
+    this.overview,
+    this.stillPath,
+    this.voteAverage,
+    this.airDate,
+  });
+
+  String get stillUrl => TmdbClient.stillUrl(stillPath);
+
+  factory TmdbEpisode.fromJson(Map<String, dynamic> json) {
+    return TmdbEpisode(
+      episodeNumber: json['episode_number'] as int,
+      seasonNumber: json['season_number'] as int,
+      name: json['name'] as String?,
+      overview: json['overview'] as String?,
+      stillPath: json['still_path'] as String?,
+      voteAverage: (json['vote_average'] as num?)?.toDouble(),
+      airDate: json['air_date'] as String?,
+    );
+  }
+}
+
+/// TMDB search result
+class TmdbSearchResult {
+  final int id;
+  final String? name;
+  final String? title;
+  final String? posterPath;
+  final String? overview;
+  final double? voteAverage;
+
+  const TmdbSearchResult({
+    required this.id,
+    this.name,
+    this.title,
+    this.posterPath,
+    this.overview,
+    this.voteAverage,
+  });
+
+  String get displayName => name ?? title ?? 'Unknown';
+  String get posterUrl => TmdbClient.posterUrl(posterPath);
+
+  factory TmdbSearchResult.fromJson(Map<String, dynamic> json) {
+    return TmdbSearchResult(
+      id: json['id'] as int,
+      name: json['name'] as String?,
+      title: json['title'] as String?,
+      posterPath: json['poster_path'] as String?,
+      overview: json['overview'] as String?,
+      voteAverage: (json['vote_average'] as num?)?.toDouble(),
+    );
+  }
+}

--- a/lib/data/datasources/remote/torrent_search_client.dart
+++ b/lib/data/datasources/remote/torrent_search_client.dart
@@ -1,0 +1,126 @@
+import 'package:dio/dio.dart';
+
+/// Searches for torrent hashes by IMDB ID using the Torrentio addon API
+/// Torrentio is a Stremio addon that aggregates torrent sources
+/// This only uses the public addon API (no Stremio dependency)
+class TorrentSearchClient {
+  final Dio _dio;
+
+  static const _torrentioBase = 'https://torrentio.strem.fun';
+
+  TorrentSearchClient({Dio? dio}) : _dio = dio ?? Dio() {
+    _dio.options
+      ..connectTimeout = const Duration(seconds: 10)
+      ..receiveTimeout = const Duration(seconds: 15);
+  }
+
+  /// Search for streams by IMDB ID (for movies)
+  Future<List<TorrentResult>> searchMovie(String imdbId) async {
+    return _search('movie', imdbId);
+  }
+
+  /// Search for streams by IMDB ID + season + episode (for TV shows)
+  Future<List<TorrentResult>> searchEpisode(
+    String imdbId, {
+    required int season,
+    required int episode,
+  }) async {
+    return _search('series', '$imdbId:$season:$episode');
+  }
+
+  Future<List<TorrentResult>> _search(String type, String id) async {
+    try {
+      final response = await _dio.get('$_torrentioBase/stream/$type/$id.json');
+      final data = response.data as Map<String, dynamic>;
+      final streams = data['streams'] as List? ?? [];
+
+      return streams.map((s) {
+        final stream = s as Map<String, dynamic>;
+        final title = stream['title'] as String? ?? '';
+        final name = stream['name'] as String? ?? '';
+
+        // Extract info hash from the infoHash field or magnet URL
+        String? infoHash = stream['infoHash'] as String?;
+        if (infoHash == null) {
+          final url = stream['url'] as String? ?? '';
+          final hashMatch = RegExp(r'btih:([a-fA-F0-9]{40})').firstMatch(url);
+          infoHash = hashMatch?.group(1);
+        }
+
+        return TorrentResult(
+          title: title,
+          name: name,
+          infoHash: infoHash ?? '',
+          quality: _extractQuality(title),
+          filesize: _extractFilesize(title),
+          seeds: _extractSeeds(title),
+          magnetUrl: _buildMagnet(infoHash ?? '', name),
+        );
+      }).where((r) => r.infoHash.isNotEmpty).toList();
+    } catch (e) {
+      // Torrentio may be unavailable; return empty list
+      return [];
+    }
+  }
+
+  String _extractQuality(String title) {
+    if (title.contains('2160p') || title.contains('4K')) return '4K';
+    if (title.contains('1080p')) return '1080p';
+    if (title.contains('720p')) return '720p';
+    if (title.contains('480p')) return '480p';
+    return '';
+  }
+
+  String? _extractFilesize(String title) {
+    final match = RegExp(r'(\d+\.?\d*)\s*(GB|MB)', caseSensitive: false).firstMatch(title);
+    return match?.group(0);
+  }
+
+  int? _extractSeeds(String title) {
+    final match = RegExp(r'👤\s*(\d+)').firstMatch(title);
+    if (match != null) return int.tryParse(match.group(1)!);
+    return null;
+  }
+
+  String _buildMagnet(String hash, String name) {
+    final encoded = Uri.encodeComponent(name);
+    return 'magnet:?xt=urn:btih:$hash&dn=$encoded';
+  }
+}
+
+/// A torrent search result with hash for debrid lookup
+class TorrentResult {
+  final String title;
+  final String name;
+  final String infoHash;
+  final String quality;
+  final String? filesize;
+  final int? seeds;
+  final String magnetUrl;
+
+  const TorrentResult({
+    required this.title,
+    required this.name,
+    required this.infoHash,
+    this.quality = '',
+    this.filesize,
+    this.seeds,
+    required this.magnetUrl,
+  });
+
+  /// Sort quality: 4K > 1080p > 720p > unknown
+  int get qualityScore {
+    switch (quality) {
+      case '4K':
+        return 4;
+      case '1080p':
+        return 3;
+      case '720p':
+        return 2;
+      case '480p':
+        return 1;
+      default:
+        return 0;
+    }
+  }
+}

--- a/lib/data/datasources/remote/trakt_client.dart
+++ b/lib/data/datasources/remote/trakt_client.dart
@@ -1,0 +1,201 @@
+import 'package:dio/dio.dart';
+import '../../models/show.dart';
+
+/// Client for the Trakt.tv API v2
+/// Docs: https://trakt.docs.apiary.io/
+class TraktClient {
+  final Dio _dio;
+  final String clientId;
+
+  static const _baseUrl = 'https://api.trakt.tv';
+
+  TraktClient({
+    required this.clientId,
+    Dio? dio,
+  }) : _dio = dio ?? Dio() {
+    _dio.options
+      ..baseUrl = _baseUrl
+      ..connectTimeout = const Duration(seconds: 10)
+      ..receiveTimeout = const Duration(seconds: 15)
+      ..headers = {
+        'Content-Type': 'application/json',
+        'trakt-api-version': '2',
+        'trakt-api-key': clientId,
+      };
+  }
+
+  /// Get trending TV shows
+  Future<List<Show>> getTrendingShows({int page = 1, int limit = 20}) async {
+    final response = await _dio.get(
+      '/shows/trending',
+      queryParameters: {
+        'page': page,
+        'limit': limit,
+        'extended': 'full',
+      },
+    );
+    return (response.data as List).map((e) {
+      final show = e['show'] as Map<String, dynamic>;
+      return _showFromTrakt(show);
+    }).toList();
+  }
+
+  /// Get popular TV shows
+  Future<List<Show>> getPopularShows({int page = 1, int limit = 20}) async {
+    final response = await _dio.get(
+      '/shows/popular',
+      queryParameters: {
+        'page': page,
+        'limit': limit,
+        'extended': 'full',
+      },
+    );
+    return (response.data as List).map((e) {
+      return _showFromTrakt(e as Map<String, dynamic>);
+    }).toList();
+  }
+
+  /// Get trending movies
+  Future<List<Show>> getTrendingMovies({int page = 1, int limit = 20}) async {
+    final response = await _dio.get(
+      '/movies/trending',
+      queryParameters: {
+        'page': page,
+        'limit': limit,
+        'extended': 'full',
+      },
+    );
+    return (response.data as List).map((e) {
+      final movie = e['movie'] as Map<String, dynamic>;
+      return _showFromTrakt(movie, type: ShowType.movie);
+    }).toList();
+  }
+
+  /// Get popular movies
+  Future<List<Show>> getPopularMovies({int page = 1, int limit = 20}) async {
+    final response = await _dio.get(
+      '/movies/popular',
+      queryParameters: {
+        'page': page,
+        'limit': limit,
+        'extended': 'full',
+      },
+    );
+    return (response.data as List).map((e) {
+      return _showFromTrakt(e as Map<String, dynamic>, type: ShowType.movie);
+    }).toList();
+  }
+
+  /// Search for shows and movies
+  Future<List<Show>> search(String query, {String type = 'show,movie'}) async {
+    final response = await _dio.get(
+      '/search/$type',
+      queryParameters: {
+        'query': query,
+        'extended': 'full',
+        'limit': 20,
+      },
+    );
+    return (response.data as List).map((e) {
+      final itemType = e['type'] as String;
+      final item = e[itemType] as Map<String, dynamic>;
+      return _showFromTrakt(
+        item,
+        type: itemType == 'movie' ? ShowType.movie : ShowType.show,
+      );
+    }).toList();
+  }
+
+  /// Get seasons for a show
+  Future<List<Season>> getSeasons(int traktId) async {
+    final response = await _dio.get(
+      '/shows/$traktId/seasons',
+      queryParameters: {'extended': 'full'},
+    );
+    return (response.data as List).map((e) {
+      final json = e as Map<String, dynamic>;
+      return Season(
+        number: json['number'] as int,
+        title: json['title'] as String?,
+        overview: json['overview'] as String?,
+        episodeCount: json['episode_count'] as int?,
+        airedEpisodes: json['aired_episodes'] as int?,
+        rating: (json['rating'] as num?)?.toDouble(),
+        firstAired: json['first_aired'] != null
+            ? DateTime.tryParse(json['first_aired'] as String)
+            : null,
+        traktId: (json['ids'] as Map<String, dynamic>?)?['trakt'] as int?,
+        tmdbId: (json['ids'] as Map<String, dynamic>?)?['tmdb'] as int?,
+      );
+    }).toList();
+  }
+
+  /// Get episodes for a season
+  Future<List<Episode>> getEpisodes(int traktId, int seasonNumber) async {
+    final response = await _dio.get(
+      '/shows/$traktId/seasons/$seasonNumber',
+      queryParameters: {'extended': 'full'},
+    );
+    return (response.data as List).map((e) {
+      final json = e as Map<String, dynamic>;
+      return Episode(
+        season: json['season'] as int,
+        number: json['number'] as int,
+        title: json['title'] as String?,
+        overview: json['overview'] as String?,
+        rating: (json['rating'] as num?)?.toDouble(),
+        votes: json['votes'] as int?,
+        runtime: json['runtime'] as int?,
+        firstAired: json['first_aired'] != null
+            ? DateTime.tryParse(json['first_aired'] as String)
+            : null,
+        traktId: (json['ids'] as Map<String, dynamic>?)?['trakt'] as int?,
+        tmdbId: (json['ids'] as Map<String, dynamic>?)?['tmdb'] as int?,
+      );
+    }).toList();
+  }
+
+  /// Get show details by Trakt ID
+  Future<Show> getShow(int traktId) async {
+    final response = await _dio.get(
+      '/shows/$traktId',
+      queryParameters: {'extended': 'full'},
+    );
+    return _showFromTrakt(response.data as Map<String, dynamic>);
+  }
+
+  /// Get movie details by Trakt ID
+  Future<Show> getMovie(int traktId) async {
+    final response = await _dio.get(
+      '/movies/$traktId',
+      queryParameters: {'extended': 'full'},
+    );
+    return _showFromTrakt(
+      response.data as Map<String, dynamic>,
+      type: ShowType.movie,
+    );
+  }
+
+  Show _showFromTrakt(Map<String, dynamic> json, {ShowType type = ShowType.show}) {
+    final ids = json['ids'] as Map<String, dynamic>? ?? {};
+    return Show(
+      traktId: ids['trakt'] as int? ?? 0,
+      imdbId: ids['imdb'] as String?,
+      tmdbId: ids['tmdb'] as int?,
+      title: json['title'] as String? ?? 'Unknown',
+      year: json['year'] as int?,
+      overview: json['overview'] as String?,
+      rating: (json['rating'] as num?)?.toDouble(),
+      votes: json['votes'] as int?,
+      status: json['status'] as String?,
+      network: json['network'] as String?,
+      genres: (json['genres'] as List?)?.cast<String>() ?? [],
+      runtime: json['runtime'] as int?,
+      type: type,
+      firstAired: json['first_aired'] != null
+          ? DateTime.tryParse(json['first_aired'] as String)
+          : null,
+      trailer: json['trailer'] as String?,
+    );
+  }
+}

--- a/lib/data/models/show.dart
+++ b/lib/data/models/show.dart
@@ -1,0 +1,181 @@
+import 'package:equatable/equatable.dart';
+
+/// Represents a TV show or movie from Trakt/TMDB
+class Show extends Equatable {
+  final int traktId;
+  final String? imdbId;
+  final int? tmdbId;
+  final String title;
+  final int? year;
+  final String? overview;
+  final double? rating;
+  final int? votes;
+  final String? status; // "returning series", "ended", etc.
+  final String? network;
+  final List<String> genres;
+  final String? posterUrl;
+  final String? backdropUrl;
+  final String? trailer;
+  final int? runtime; // minutes
+  final ShowType type;
+  final DateTime? firstAired;
+
+  const Show({
+    required this.traktId,
+    this.imdbId,
+    this.tmdbId,
+    required this.title,
+    this.year,
+    this.overview,
+    this.rating,
+    this.votes,
+    this.status,
+    this.network,
+    this.genres = const [],
+    this.posterUrl,
+    this.backdropUrl,
+    this.trailer,
+    this.runtime,
+    this.type = ShowType.show,
+    this.firstAired,
+  });
+
+  Show copyWith({
+    String? posterUrl,
+    String? backdropUrl,
+    String? overview,
+    double? rating,
+    int? votes,
+    List<String>? genres,
+    String? status,
+    String? trailer,
+  }) {
+    return Show(
+      traktId: traktId,
+      imdbId: imdbId,
+      tmdbId: tmdbId,
+      title: title,
+      year: year,
+      overview: overview ?? this.overview,
+      rating: rating ?? this.rating,
+      votes: votes ?? this.votes,
+      status: status ?? this.status,
+      network: network,
+      genres: genres ?? this.genres,
+      posterUrl: posterUrl ?? this.posterUrl,
+      backdropUrl: backdropUrl ?? this.backdropUrl,
+      trailer: trailer ?? this.trailer,
+      runtime: runtime,
+      type: type,
+      firstAired: firstAired,
+    );
+  }
+
+  @override
+  List<Object?> get props => [traktId, imdbId];
+}
+
+enum ShowType { show, movie }
+
+/// Represents a season of a TV show
+class Season extends Equatable {
+  final int number;
+  final String? title;
+  final String? overview;
+  final int? episodeCount;
+  final int? airedEpisodes;
+  final double? rating;
+  final String? posterUrl;
+  final DateTime? firstAired;
+  final int? traktId;
+  final int? tmdbId;
+
+  const Season({
+    required this.number,
+    this.title,
+    this.overview,
+    this.episodeCount,
+    this.airedEpisodes,
+    this.rating,
+    this.posterUrl,
+    this.firstAired,
+    this.traktId,
+    this.tmdbId,
+  });
+
+  String get displayTitle => title ?? 'Season $number';
+
+  @override
+  List<Object?> get props => [number, traktId];
+}
+
+/// Represents an episode of a TV show
+class Episode extends Equatable {
+  final int season;
+  final int number;
+  final String? title;
+  final String? overview;
+  final double? rating;
+  final int? votes;
+  final int? runtime; // minutes
+  final DateTime? firstAired;
+  final String? stillUrl; // episode screenshot
+  final int? traktId;
+  final int? tmdbId;
+
+  const Episode({
+    required this.season,
+    required this.number,
+    this.title,
+    this.overview,
+    this.rating,
+    this.votes,
+    this.runtime,
+    this.firstAired,
+    this.stillUrl,
+    this.traktId,
+    this.tmdbId,
+  });
+
+  String get displayTitle => title ?? 'Episode $number';
+  String get code => 'S${season.toString().padLeft(2, '0')}E${number.toString().padLeft(2, '0')}';
+
+  @override
+  List<Object?> get props => [season, number, traktId];
+}
+
+/// Full detail for a show including seasons list
+class ShowDetail {
+  final Show show;
+  final List<Season> seasons;
+
+  const ShowDetail({required this.show, this.seasons = const []});
+}
+
+/// A resolved stream link ready for playback
+class ResolvedStream extends Equatable {
+  final String url;
+  final String filename;
+  final String? quality; // "1080p", "720p", "4K", etc.
+  final int? filesize; // bytes
+  final String source; // "real-debrid", "direct", etc.
+
+  const ResolvedStream({
+    required this.url,
+    required this.filename,
+    this.quality,
+    this.filesize,
+    this.source = 'real-debrid',
+  });
+
+  String get filesizeDisplay {
+    if (filesize == null) return '';
+    final gb = filesize! / (1024 * 1024 * 1024);
+    if (gb >= 1) return '${gb.toStringAsFixed(1)} GB';
+    final mb = filesize! / (1024 * 1024);
+    return '${mb.toStringAsFixed(0)} MB';
+  }
+
+  @override
+  List<Object?> get props => [url];
+}

--- a/lib/data/repositories/shows_repository.dart
+++ b/lib/data/repositories/shows_repository.dart
@@ -1,0 +1,248 @@
+import 'package:logger/logger.dart';
+import '../datasources/remote/trakt_client.dart';
+import '../datasources/remote/tmdb_client.dart';
+import '../datasources/remote/debrid_client.dart';
+import '../datasources/remote/torrent_search_client.dart';
+import '../models/show.dart';
+
+/// Combines Trakt, TMDB, debrid, and torrent search into a unified shows data source
+class ShowsRepository {
+  final TraktClient? _trakt;
+  final TmdbClient? _tmdb;
+  final DebridClient? _debrid;
+  final TorrentSearchClient _torrentSearch;
+  final _log = Logger(printer: SimplePrinter());
+
+  ShowsRepository({
+    TraktClient? trakt,
+    TmdbClient? tmdb,
+    DebridClient? debrid,
+    TorrentSearchClient? torrentSearch,
+  })  : _trakt = trakt,
+        _tmdb = tmdb,
+        _debrid = debrid,
+        _torrentSearch = torrentSearch ?? TorrentSearchClient();
+
+  bool get hasTrakt => _trakt != null;
+  bool get hasTmdb => _tmdb != null;
+  bool get hasDebrid => _debrid != null;
+
+  /// Get trending shows, enriched with TMDB posters
+  Future<List<Show>> getTrendingShows({int page = 1, int limit = 20}) async {
+    if (_trakt == null) return [];
+    final shows = await _trakt.getTrendingShows(page: page, limit: limit);
+    return _enrichWithTmdb(shows);
+  }
+
+  /// Get popular shows, enriched with TMDB posters
+  Future<List<Show>> getPopularShows({int page = 1, int limit = 20}) async {
+    if (_trakt == null) return [];
+    final shows = await _trakt.getPopularShows(page: page, limit: limit);
+    return _enrichWithTmdb(shows);
+  }
+
+  /// Get trending movies, enriched with TMDB posters
+  Future<List<Show>> getTrendingMovies({int page = 1, int limit = 20}) async {
+    if (_trakt == null) return [];
+    final shows = await _trakt.getTrendingMovies(page: page, limit: limit);
+    return _enrichWithTmdb(shows);
+  }
+
+  /// Get popular movies, enriched with TMDB posters
+  Future<List<Show>> getPopularMovies({int page = 1, int limit = 20}) async {
+    if (_trakt == null) return [];
+    final shows = await _trakt.getPopularMovies(page: page, limit: limit);
+    return _enrichWithTmdb(shows);
+  }
+
+  /// Search shows and movies
+  Future<List<Show>> search(String query) async {
+    if (_trakt == null) return [];
+    final results = await _trakt.search(query);
+    return _enrichWithTmdb(results);
+  }
+
+  /// Get full show detail with seasons
+  Future<ShowDetail?> getShowDetail(int traktId, {ShowType type = ShowType.show}) async {
+    if (_trakt == null) return null;
+
+    final show = type == ShowType.movie
+        ? await _trakt.getMovie(traktId)
+        : await _trakt.getShow(traktId);
+
+    // Enrich with TMDB images
+    final enriched = await _enrichSingle(show);
+
+    // Get seasons (only for shows)
+    List<Season> seasons = [];
+    if (type == ShowType.show) {
+      seasons = await _trakt.getSeasons(traktId);
+      // Filter out specials (season 0) by default
+      seasons = seasons.where((s) => s.number > 0).toList();
+
+      // Enrich seasons with TMDB posters
+      if (_tmdb != null && enriched.tmdbId != null) {
+        for (var i = 0; i < seasons.length; i++) {
+          try {
+            final tmdbSeason = await _tmdb.getTvSeason(enriched.tmdbId!, seasons[i].number);
+            seasons[i] = Season(
+              number: seasons[i].number,
+              title: seasons[i].title,
+              overview: tmdbSeason.overview ?? seasons[i].overview,
+              episodeCount: seasons[i].episodeCount,
+              airedEpisodes: seasons[i].airedEpisodes,
+              rating: seasons[i].rating,
+              posterUrl: tmdbSeason.posterPath != null
+                  ? TmdbClient.posterUrl(tmdbSeason.posterPath)
+                  : null,
+              firstAired: seasons[i].firstAired,
+              traktId: seasons[i].traktId,
+              tmdbId: seasons[i].tmdbId,
+            );
+          } catch (_) {
+            // TMDB enrichment failed; keep Trakt data
+          }
+        }
+      }
+    }
+
+    return ShowDetail(show: enriched, seasons: seasons);
+  }
+
+  /// Get episodes for a season
+  Future<List<Episode>> getEpisodes(int traktId, int seasonNumber) async {
+    if (_trakt == null) return [];
+    final episodes = await _trakt.getEpisodes(traktId, seasonNumber);
+
+    // Enrich with TMDB stills
+    if (_tmdb != null) {
+      // We need the TMDB ID — look it up from the show
+      try {
+        final show = await _trakt.getShow(traktId);
+        if (show.tmdbId != null) {
+          final tmdbSeason = await _tmdb.getTvSeason(show.tmdbId!, seasonNumber);
+          final tmdbEpMap = {for (final e in tmdbSeason.episodes) e.episodeNumber: e};
+
+          return episodes.map((ep) {
+            final tmdbEp = tmdbEpMap[ep.number];
+            if (tmdbEp == null) return ep;
+            return Episode(
+              season: ep.season,
+              number: ep.number,
+              title: ep.title ?? tmdbEp.name,
+              overview: ep.overview ?? tmdbEp.overview,
+              rating: ep.rating,
+              votes: ep.votes,
+              runtime: ep.runtime,
+              firstAired: ep.firstAired,
+              stillUrl: tmdbEp.stillUrl.isNotEmpty ? tmdbEp.stillUrl : null,
+              traktId: ep.traktId,
+              tmdbId: ep.tmdbId,
+            );
+          }).toList();
+        }
+      } catch (_) {
+        // TMDB enrichment failed; return Trakt data
+      }
+    }
+
+    return episodes;
+  }
+
+  /// Resolve a stream URL for a show/movie via debrid
+  /// Returns sorted list of available streams (best quality first)
+  Future<List<ResolvedStream>> resolveStreams({
+    required String imdbId,
+    int? season,
+    int? episode,
+  }) async {
+    // Step 1: Search for torrent hashes
+    List<TorrentResult> torrents;
+    if (season != null && episode != null) {
+      torrents = await _torrentSearch.searchEpisode(
+        imdbId,
+        season: season,
+        episode: episode,
+      );
+    } else {
+      torrents = await _torrentSearch.searchMovie(imdbId);
+    }
+
+    if (torrents.isEmpty) {
+      _log.w('No torrents found for $imdbId');
+      return [];
+    }
+
+    // Sort by quality (best first)
+    torrents.sort((a, b) => b.qualityScore.compareTo(a.qualityScore));
+
+    // Step 2: Check instant availability via debrid
+    if (_debrid == null) {
+      _log.w('No debrid client configured');
+      return [];
+    }
+
+    final hashes = torrents.map((t) => t.infoHash).toList();
+    final available = await _debrid.checkInstantAvailability(hashes);
+
+    if (available.isEmpty) {
+      _log.w('No cached torrents found on debrid for $imdbId');
+      return [];
+    }
+
+    // Step 3: Resolve the best available cached torrent
+    final resolved = <ResolvedStream>[];
+    for (final torrent in torrents) {
+      final hashLower = torrent.infoHash.toLowerCase();
+      if (available.containsKey(hashLower)) {
+        try {
+          final stream = await _debrid.resolveFromMagnet(torrent.magnetUrl);
+          if (stream != null) {
+            resolved.add(ResolvedStream(
+              url: stream.url,
+              filename: stream.filename,
+              quality: torrent.quality,
+              filesize: stream.filesize,
+              source: 'real-debrid',
+            ));
+          }
+        } catch (e) {
+          _log.e('Failed to resolve torrent ${torrent.infoHash}: $e');
+        }
+        // Return first 3 best quality options
+        if (resolved.length >= 3) break;
+      }
+    }
+
+    return resolved;
+  }
+
+  /// Enrich a list of shows with TMDB poster/backdrop URLs
+  Future<List<Show>> _enrichWithTmdb(List<Show> shows) async {
+    if (_tmdb == null) return shows;
+
+    final enriched = <Show>[];
+    for (final show in shows) {
+      enriched.add(await _enrichSingle(show));
+    }
+    return enriched;
+  }
+
+  /// Enrich a single show with TMDB images
+  Future<Show> _enrichSingle(Show show) async {
+    if (_tmdb == null || show.tmdbId == null) return show;
+    try {
+      final detail = show.type == ShowType.movie
+          ? await _tmdb.getMovie(show.tmdbId!)
+          : await _tmdb.getTvShow(show.tmdbId!);
+      return show.copyWith(
+        posterUrl: detail.posterUrl.isNotEmpty ? detail.posterUrl : null,
+        backdropUrl: detail.backdropUrl.isNotEmpty ? detail.backdropUrl : null,
+        overview: show.overview ?? detail.overview,
+      );
+    } catch (e) {
+      _log.w('TMDB enrichment failed for ${show.title}: $e');
+      return show;
+    }
+  }
+}

--- a/lib/features/channels/channels_screen.dart
+++ b/lib/features/channels/channels_screen.dart
@@ -805,6 +805,11 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
             tooltip: 'Settings',
             onPressed: () => context.push('/settings'),
           ),
+          IconButton(
+            icon: const Icon(Icons.movie_rounded, color: Colors.white70),
+            tooltip: 'Shows & Movies',
+            onPressed: () => context.push('/shows'),
+          ),
         ],
       ),
     );

--- a/lib/features/shows/show_detail_screen.dart
+++ b/lib/features/shows/show_detail_screen.dart
@@ -1,0 +1,440 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:go_router/go_router.dart';
+import '../../data/models/show.dart';
+import 'shows_providers.dart';
+
+/// Detail screen for a show or movie — backdrop, info, seasons, episodes, play
+class ShowDetailScreen extends ConsumerStatefulWidget {
+  final int traktId;
+  final Show? initialShow; // Passed via extra for instant display
+
+  const ShowDetailScreen({
+    super.key,
+    required this.traktId,
+    this.initialShow,
+  });
+
+  @override
+  ConsumerState<ShowDetailScreen> createState() => _ShowDetailScreenState();
+}
+
+class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
+  int _selectedSeason = 1;
+  bool _resolving = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final type = widget.initialShow?.type ?? ShowType.show;
+    final detailAsync = ref.watch(
+      showDetailProvider(ShowDetailParams(widget.traktId, type: type)),
+    );
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF0A0A1A),
+      body: detailAsync.when(
+        loading: () => _buildWithShow(widget.initialShow, loading: true),
+        error: (err, _) => _buildError(err),
+        data: (detail) {
+          if (detail == null) return _buildError('Show not found');
+          return _buildDetail(detail);
+        },
+      ),
+    );
+  }
+
+  Widget _buildWithShow(Show? show, {bool loading = false}) {
+    if (show == null) {
+      return const Center(
+        child: CircularProgressIndicator(color: Color(0xFF6C5CE7)),
+      );
+    }
+    return _buildDetail(ShowDetail(show: show), loading: loading);
+  }
+
+  Widget _buildError(Object error) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, color: Colors.redAccent, size: 48),
+          const SizedBox(height: 12),
+          Text('$error', style: const TextStyle(color: Colors.white60)),
+          const SizedBox(height: 16),
+          TextButton(
+            onPressed: () => context.go('/shows'),
+            child: const Text('Go Back'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDetail(ShowDetail detail, {bool loading = false}) {
+    final show = detail.show;
+    return CustomScrollView(
+      slivers: [
+        // Backdrop + back button
+        SliverAppBar(
+          expandedHeight: 300,
+          pinned: true,
+          backgroundColor: const Color(0xFF0A0A1A),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back, color: Colors.white),
+            onPressed: () => context.go('/shows'),
+          ),
+          flexibleSpace: FlexibleSpaceBar(
+            background: Stack(
+              fit: StackFit.expand,
+              children: [
+                if (show.backdropUrl != null && show.backdropUrl!.isNotEmpty)
+                  CachedNetworkImage(
+                    imageUrl: show.backdropUrl!,
+                    fit: BoxFit.cover,
+                    errorWidget: (_, __, ___) => Container(color: const Color(0xFF1A1A2E)),
+                  )
+                else
+                  Container(color: const Color(0xFF1A1A2E)),
+                // Gradient overlay
+                const DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [Colors.transparent, Color(0xFF0A0A1A)],
+                      stops: [0.5, 1.0],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+
+        // Show info
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 0, 24, 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Title + year
+                Text(
+                  show.title,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 28,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                // Meta row
+                Wrap(
+                  spacing: 12,
+                  children: [
+                    if (show.year != null)
+                      _chip('${show.year}'),
+                    if (show.rating != null)
+                      _chip('★ ${show.rating!.toStringAsFixed(1)}'),
+                    if (show.runtime != null)
+                      _chip('${show.runtime} min'),
+                    if (show.status != null)
+                      _chip(show.status!),
+                    if (show.network != null)
+                      _chip(show.network!),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                // Genres
+                if (show.genres.isNotEmpty)
+                  Wrap(
+                    spacing: 8,
+                    children: show.genres
+                        .take(5)
+                        .map((g) => Chip(
+                              label: Text(g, style: const TextStyle(fontSize: 11)),
+                              backgroundColor: const Color(0xFF1A1A2E),
+                              labelStyle: const TextStyle(color: Colors.white60),
+                              side: BorderSide.none,
+                              padding: EdgeInsets.zero,
+                              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                            ))
+                        .toList(),
+                  ),
+                const SizedBox(height: 16),
+                // Overview
+                if (show.overview != null)
+                  Text(
+                    show.overview!,
+                    style: const TextStyle(color: Colors.white70, fontSize: 15, height: 1.5),
+                  ),
+                const SizedBox(height: 20),
+
+                // Play button (for movies) or Season selector (for shows)
+                if (show.type == ShowType.movie) _buildPlayMovieButton(show),
+
+                if (loading)
+                  const Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Center(
+                      child: CircularProgressIndicator(color: Color(0xFF6C5CE7)),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+
+        // Seasons tabs (for TV shows)
+        if (show.type == ShowType.show && detail.seasons.isNotEmpty) ...[
+          SliverToBoxAdapter(
+            child: SizedBox(
+              height: 48,
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                itemCount: detail.seasons.length,
+                itemBuilder: (context, index) {
+                  final season = detail.seasons[index];
+                  final selected = season.number == _selectedSeason;
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: ChoiceChip(
+                      label: Text('Season ${season.number}'),
+                      selected: selected,
+                      selectedColor: const Color(0xFF6C5CE7),
+                      backgroundColor: const Color(0xFF1A1A2E),
+                      labelStyle: TextStyle(
+                        color: selected ? Colors.white : Colors.white60,
+                      ),
+                      side: BorderSide.none,
+                      onSelected: (_) => setState(() => _selectedSeason = season.number),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+          // Episodes list
+          _buildEpisodesList(show),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildPlayMovieButton(Show show) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton.icon(
+        onPressed: _resolving ? null : () => _playContent(show),
+        icon: _resolving
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+              )
+            : const Icon(Icons.play_arrow),
+        label: Text(_resolving ? 'Finding stream...' : 'Play'),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF6C5CE7),
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          textStyle: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEpisodesList(Show show) {
+    final episodesAsync = ref.watch(
+      episodesProvider(EpisodeParams(widget.traktId, _selectedSeason)),
+    );
+
+    return episodesAsync.when(
+      loading: () => const SliverToBoxAdapter(
+        child: Padding(
+          padding: EdgeInsets.all(32),
+          child: Center(child: CircularProgressIndicator(color: Color(0xFF6C5CE7))),
+        ),
+      ),
+      error: (err, _) => SliverToBoxAdapter(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text('Error: $err', style: const TextStyle(color: Colors.redAccent)),
+        ),
+      ),
+      data: (episodes) => SliverList(
+        delegate: SliverChildBuilderDelegate(
+          (context, index) => _EpisodeTile(
+            episode: episodes[index],
+            show: show,
+            onPlay: () => _playEpisode(show, episodes[index]),
+          ),
+          childCount: episodes.length,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _playContent(Show show) async {
+    if (show.imdbId == null) {
+      _showSnackbar('No IMDB ID available for this title');
+      return;
+    }
+    setState(() => _resolving = true);
+    try {
+      final streams = await ref.read(
+        resolveStreamProvider(StreamResolveParams(show.imdbId!)).future,
+      );
+      if (streams.isEmpty) {
+        _showSnackbar('No cached streams found');
+        return;
+      }
+      // Play the best quality stream
+      _launchPlayer(streams.first, show.title);
+    } catch (e) {
+      _showSnackbar('Stream error: $e');
+    } finally {
+      setState(() => _resolving = false);
+    }
+  }
+
+  Future<void> _playEpisode(Show show, Episode episode) async {
+    if (show.imdbId == null) {
+      _showSnackbar('No IMDB ID available');
+      return;
+    }
+    setState(() => _resolving = true);
+    try {
+      final streams = await ref.read(
+        resolveStreamProvider(StreamResolveParams(
+          show.imdbId!,
+          season: episode.season,
+          episode: episode.number,
+        )).future,
+      );
+      if (streams.isEmpty) {
+        _showSnackbar('No cached streams found for ${episode.code}');
+        return;
+      }
+      _launchPlayer(streams.first, '${show.title} ${episode.code}');
+    } catch (e) {
+      _showSnackbar('Stream error: $e');
+    } finally {
+      setState(() => _resolving = false);
+    }
+  }
+
+  void _launchPlayer(ResolvedStream stream, String title) {
+    context.go('/player', extra: {
+      'streamUrl': stream.url,
+      'channelName': title,
+      'channelLogo': widget.initialShow?.posterUrl ?? '',
+    });
+  }
+
+  void _showSnackbar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message), backgroundColor: const Color(0xFF1A1A2E)),
+    );
+  }
+
+  Widget _chip(String text) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1A1A2E),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(text, style: const TextStyle(color: Colors.white60, fontSize: 13)),
+    );
+  }
+}
+
+class _EpisodeTile extends StatelessWidget {
+  final Episode episode;
+  final Show show;
+  final VoidCallback onPlay;
+
+  const _EpisodeTile({
+    required this.episode,
+    required this.show,
+    required this.onPlay,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onPlay,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+        child: Row(
+          children: [
+            // Episode thumbnail
+            ClipRRect(
+              borderRadius: BorderRadius.circular(6),
+              child: SizedBox(
+                width: 120,
+                height: 68,
+                child: episode.stillUrl != null && episode.stillUrl!.isNotEmpty
+                    ? CachedNetworkImage(
+                        imageUrl: episode.stillUrl!,
+                        fit: BoxFit.cover,
+                        errorWidget: (_, __, ___) => _placeholder(),
+                      )
+                    : _placeholder(),
+              ),
+            ),
+            const SizedBox(width: 12),
+            // Episode info
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${episode.number}. ${episode.displayTitle}',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  if (episode.overview != null)
+                    Text(
+                      episode.overview!,
+                      style: const TextStyle(color: Colors.white38, fontSize: 12),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  if (episode.runtime != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        '${episode.runtime} min',
+                        style: const TextStyle(color: Colors.white24, fontSize: 11),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            // Play icon
+            const Icon(Icons.play_circle_outline, color: Color(0xFF6C5CE7), size: 32),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _placeholder() {
+    return Container(
+      color: const Color(0xFF1A1A2E),
+      child: const Center(
+        child: Icon(Icons.play_arrow, color: Colors.white24),
+      ),
+    );
+  }
+}

--- a/lib/features/shows/shows_providers.dart
+++ b/lib/features/shows/shows_providers.dart
@@ -1,0 +1,195 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../data/datasources/remote/trakt_client.dart';
+import '../../data/datasources/remote/tmdb_client.dart';
+import '../../data/datasources/remote/debrid_client.dart';
+import '../../data/datasources/remote/torrent_search_client.dart';
+import '../../data/repositories/shows_repository.dart';
+import '../../data/models/show.dart';
+
+// SharedPreferences keys for API credentials
+const _kTraktClientId = 'shows_trakt_client_id';
+const _kTmdbApiKey = 'shows_tmdb_api_key';
+const _kDebridApiToken = 'shows_debrid_api_token';
+
+/// Provider for the shows repository (initialized from saved API keys)
+final showsRepositoryProvider = FutureProvider<ShowsRepository>((ref) async {
+  final prefs = await SharedPreferences.getInstance();
+
+  final traktId = prefs.getString(_kTraktClientId);
+  final tmdbKey = prefs.getString(_kTmdbApiKey);
+  final debridToken = prefs.getString(_kDebridApiToken);
+
+  return ShowsRepository(
+    trakt: traktId != null && traktId.isNotEmpty
+        ? TraktClient(clientId: traktId)
+        : null,
+    tmdb: tmdbKey != null && tmdbKey.isNotEmpty
+        ? TmdbClient(apiKey: tmdbKey)
+        : null,
+    debrid: debridToken != null && debridToken.isNotEmpty
+        ? DebridClient(apiToken: debridToken)
+        : null,
+    torrentSearch: TorrentSearchClient(),
+  );
+});
+
+/// Trending shows
+final trendingShowsProvider = FutureProvider<List<Show>>((ref) async {
+  final repo = await ref.watch(showsRepositoryProvider.future);
+  return repo.getTrendingShows();
+});
+
+/// Popular shows
+final popularShowsProvider = FutureProvider<List<Show>>((ref) async {
+  final repo = await ref.watch(showsRepositoryProvider.future);
+  return repo.getPopularShows();
+});
+
+/// Trending movies
+final trendingMoviesProvider = FutureProvider<List<Show>>((ref) async {
+  final repo = await ref.watch(showsRepositoryProvider.future);
+  return repo.getTrendingMovies();
+});
+
+/// Popular movies
+final popularMoviesProvider = FutureProvider<List<Show>>((ref) async {
+  final repo = await ref.watch(showsRepositoryProvider.future);
+  return repo.getPopularMovies();
+});
+
+/// Search results
+final showSearchQueryProvider = StateProvider<String>((ref) => '');
+
+final showSearchResultsProvider = FutureProvider<List<Show>>((ref) async {
+  final query = ref.watch(showSearchQueryProvider);
+  if (query.isEmpty) return [];
+  final repo = await ref.watch(showsRepositoryProvider.future);
+  return repo.search(query);
+});
+
+/// Show detail provider (family — parameterized by trakt ID + type)
+final showDetailProvider =
+    FutureProvider.family<ShowDetail?, ShowDetailParams>((ref, params) async {
+  final repo = await ref.watch(showsRepositoryProvider.future);
+  return repo.getShowDetail(params.traktId, type: params.type);
+});
+
+class ShowDetailParams {
+  final int traktId;
+  final ShowType type;
+  const ShowDetailParams(this.traktId, {this.type = ShowType.show});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ShowDetailParams && traktId == other.traktId && type == other.type;
+
+  @override
+  int get hashCode => traktId.hashCode ^ type.hashCode;
+}
+
+/// Episodes for a season
+final episodesProvider =
+    FutureProvider.family<List<Episode>, EpisodeParams>((ref, params) async {
+  final repo = await ref.watch(showsRepositoryProvider.future);
+  return repo.getEpisodes(params.traktId, params.season);
+});
+
+class EpisodeParams {
+  final int traktId;
+  final int season;
+  const EpisodeParams(this.traktId, this.season);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EpisodeParams && traktId == other.traktId && season == other.season;
+
+  @override
+  int get hashCode => traktId.hashCode ^ season.hashCode;
+}
+
+/// Stream resolution for playback
+final resolveStreamProvider =
+    FutureProvider.family<List<ResolvedStream>, StreamResolveParams>((ref, params) async {
+  final repo = await ref.watch(showsRepositoryProvider.future);
+  return repo.resolveStreams(
+    imdbId: params.imdbId,
+    season: params.season,
+    episode: params.episode,
+  );
+});
+
+class StreamResolveParams {
+  final String imdbId;
+  final int? season;
+  final int? episode;
+  const StreamResolveParams(this.imdbId, {this.season, this.episode});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is StreamResolveParams &&
+          imdbId == other.imdbId &&
+          season == other.season &&
+          episode == other.episode;
+
+  @override
+  int get hashCode => imdbId.hashCode ^ (season ?? 0).hashCode ^ (episode ?? 0).hashCode;
+}
+
+/// API keys configuration state
+class ShowsApiKeysNotifier extends StateNotifier<ShowsApiKeys> {
+  ShowsApiKeysNotifier() : super(const ShowsApiKeys());
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = ShowsApiKeys(
+      traktClientId: prefs.getString(_kTraktClientId) ?? '',
+      tmdbApiKey: prefs.getString(_kTmdbApiKey) ?? '',
+      debridApiToken: prefs.getString(_kDebridApiToken) ?? '',
+    );
+  }
+
+  Future<void> save({
+    required String traktClientId,
+    required String tmdbApiKey,
+    required String debridApiToken,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kTraktClientId, traktClientId);
+    await prefs.setString(_kTmdbApiKey, tmdbApiKey);
+    await prefs.setString(_kDebridApiToken, debridApiToken);
+    state = ShowsApiKeys(
+      traktClientId: traktClientId,
+      tmdbApiKey: tmdbApiKey,
+      debridApiToken: debridApiToken,
+    );
+  }
+}
+
+class ShowsApiKeys {
+  final String traktClientId;
+  final String tmdbApiKey;
+  final String debridApiToken;
+
+  const ShowsApiKeys({
+    this.traktClientId = '',
+    this.tmdbApiKey = '',
+    this.debridApiToken = '',
+  });
+
+  bool get isConfigured =>
+      traktClientId.isNotEmpty && tmdbApiKey.isNotEmpty && debridApiToken.isNotEmpty;
+  bool get hasTraktKey => traktClientId.isNotEmpty;
+  bool get hasTmdbKey => tmdbApiKey.isNotEmpty;
+  bool get hasDebridKey => debridApiToken.isNotEmpty;
+}
+
+final showsApiKeysProvider =
+    StateNotifierProvider<ShowsApiKeysNotifier, ShowsApiKeys>((ref) {
+  final notifier = ShowsApiKeysNotifier();
+  notifier.load();
+  return notifier;
+});

--- a/lib/features/shows/shows_screen.dart
+++ b/lib/features/shows/shows_screen.dart
@@ -1,0 +1,373 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:go_router/go_router.dart';
+import '../../data/models/show.dart';
+import 'shows_providers.dart';
+
+/// Main shows screen with poster grid organized by category
+class ShowsScreen extends ConsumerStatefulWidget {
+  const ShowsScreen({super.key});
+
+  @override
+  ConsumerState<ShowsScreen> createState() => _ShowsScreenState();
+}
+
+class _ShowsScreenState extends ConsumerState<ShowsScreen> {
+  final _searchController = TextEditingController();
+  final _searchFocusNode = FocusNode();
+  bool _isSearching = false;
+  int _selectedCategory = 0;
+
+  static const _categories = [
+    'Trending Shows',
+    'Popular Shows',
+    'Trending Movies',
+    'Popular Movies',
+  ];
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final apiKeys = ref.watch(showsApiKeysProvider);
+
+    if (!apiKeys.hasTraktKey) {
+      return _buildSetupPrompt(context);
+    }
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF0A0A1A),
+      body: KeyboardListener(
+        focusNode: FocusNode(),
+        onKeyEvent: _handleKeyEvent,
+        child: Column(
+          children: [
+            _buildHeader(context),
+            if (_isSearching) _buildSearchBar(),
+            _buildCategoryTabs(),
+            Expanded(child: _buildContent()),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSetupPrompt(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0A0A1A),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.movie_outlined, size: 64, color: Color(0xFF6C5CE7)),
+              const SizedBox(height: 24),
+              const Text(
+                'Shows & Movies',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 28,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                'Configure your API keys in Settings to browse\ntrending shows, movies, and stream via Real-Debrid.',
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Colors.white60, fontSize: 16),
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton.icon(
+                onPressed: () => context.go('/settings'),
+                icon: const Icon(Icons.settings),
+                label: const Text('Go to Settings'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF6C5CE7),
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 8),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.arrow_back, color: Colors.white),
+            onPressed: () => context.go('/'),
+          ),
+          const SizedBox(width: 12),
+          const Text(
+            'Shows & Movies',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const Spacer(),
+          IconButton(
+            icon: Icon(
+              _isSearching ? Icons.close : Icons.search,
+              color: Colors.white70,
+            ),
+            onPressed: () {
+              setState(() {
+                _isSearching = !_isSearching;
+                if (!_isSearching) {
+                  _searchController.clear();
+                  ref.read(showSearchQueryProvider.notifier).state = '';
+                }
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchBar() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+      child: TextField(
+        controller: _searchController,
+        focusNode: _searchFocusNode,
+        autofocus: true,
+        style: const TextStyle(color: Colors.white),
+        decoration: InputDecoration(
+          hintText: 'Search shows & movies...',
+          hintStyle: const TextStyle(color: Colors.white38),
+          prefixIcon: const Icon(Icons.search, color: Colors.white38),
+          filled: true,
+          fillColor: const Color(0xFF1A1A2E),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: BorderSide.none,
+          ),
+        ),
+        onChanged: (query) {
+          ref.read(showSearchQueryProvider.notifier).state = query;
+        },
+      ),
+    );
+  }
+
+  Widget _buildCategoryTabs() {
+    if (_isSearching) return const SizedBox.shrink();
+    return SizedBox(
+      height: 48,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        itemCount: _categories.length,
+        itemBuilder: (context, index) {
+          final selected = index == _selectedCategory;
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            child: ChoiceChip(
+              label: Text(_categories[index]),
+              selected: selected,
+              selectedColor: const Color(0xFF6C5CE7),
+              backgroundColor: const Color(0xFF1A1A2E),
+              labelStyle: TextStyle(
+                color: selected ? Colors.white : Colors.white60,
+                fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+              ),
+              side: BorderSide.none,
+              onSelected: (_) => setState(() => _selectedCategory = index),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_isSearching) {
+      return _buildSearchResults();
+    }
+
+    switch (_selectedCategory) {
+      case 0:
+        return _buildShowGrid(ref.watch(trendingShowsProvider));
+      case 1:
+        return _buildShowGrid(ref.watch(popularShowsProvider));
+      case 2:
+        return _buildShowGrid(ref.watch(trendingMoviesProvider));
+      case 3:
+        return _buildShowGrid(ref.watch(popularMoviesProvider));
+      default:
+        return const SizedBox.shrink();
+    }
+  }
+
+  Widget _buildSearchResults() {
+    final query = ref.watch(showSearchQueryProvider);
+    if (query.isEmpty) {
+      return const Center(
+        child: Text(
+          'Type to search...',
+          style: TextStyle(color: Colors.white38, fontSize: 16),
+        ),
+      );
+    }
+    return _buildShowGrid(ref.watch(showSearchResultsProvider));
+  }
+
+  Widget _buildShowGrid(AsyncValue<List<Show>> showsAsync) {
+    return showsAsync.when(
+      loading: () => const Center(
+        child: CircularProgressIndicator(color: Color(0xFF6C5CE7)),
+      ),
+      error: (error, _) => Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, color: Colors.redAccent, size: 48),
+            const SizedBox(height: 12),
+            Text(
+              'Failed to load: $error',
+              style: const TextStyle(color: Colors.white60),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+      data: (shows) {
+        if (shows.isEmpty) {
+          return const Center(
+            child: Text(
+              'No results found',
+              style: TextStyle(color: Colors.white38, fontSize: 16),
+            ),
+          );
+        }
+        return GridView.builder(
+          padding: const EdgeInsets.all(16),
+          gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+            maxCrossAxisExtent: 180,
+            childAspectRatio: 0.65,
+            crossAxisSpacing: 12,
+            mainAxisSpacing: 12,
+          ),
+          itemCount: shows.length,
+          itemBuilder: (context, index) => _ShowPosterCard(
+            show: shows[index],
+            onTap: () => _openShow(shows[index]),
+          ),
+        );
+      },
+    );
+  }
+
+  void _openShow(Show show) {
+    context.go('/shows/${show.traktId}', extra: show);
+  }
+
+  void _handleKeyEvent(KeyEvent event) {
+    if (event is KeyDownEvent) {
+      if (event.logicalKey == LogicalKeyboardKey.escape) {
+        if (_isSearching) {
+          setState(() {
+            _isSearching = false;
+            _searchController.clear();
+            ref.read(showSearchQueryProvider.notifier).state = '';
+          });
+        } else {
+          context.go('/');
+        }
+      }
+    }
+  }
+}
+
+class _ShowPosterCard extends StatelessWidget {
+  final Show show;
+  final VoidCallback onTap;
+
+  const _ShowPosterCard({required this.show, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: show.posterUrl != null && show.posterUrl!.isNotEmpty
+                  ? CachedNetworkImage(
+                      imageUrl: show.posterUrl!,
+                      fit: BoxFit.cover,
+                      width: double.infinity,
+                      placeholder: (_, __) => Container(
+                        color: const Color(0xFF1A1A2E),
+                        child: const Center(
+                          child: Icon(Icons.movie, color: Colors.white24, size: 40),
+                        ),
+                      ),
+                      errorWidget: (_, __, ___) => _placeholderPoster(),
+                    )
+                  : _placeholderPoster(),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            show.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          if (show.year != null)
+            Text(
+              '${show.year}${show.rating != null ? ' • ★ ${show.rating!.toStringAsFixed(1)}' : ''}',
+              style: const TextStyle(color: Colors.white38, fontSize: 11),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _placeholderPoster() {
+    return Container(
+      color: const Color(0xFF1A1A2E),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.movie, color: Colors.white24, size: 40),
+            const SizedBox(height: 4),
+            Text(
+              show.title,
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Colors.white38, fontSize: 10),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds a complete Shows & Movies feature to clubTivi, blending on-demand content into the TV experience.

### Data Layer
- **Models**: Show, Season, Episode, ShowDetail, ResolvedStream (Equatable)
- **TraktClient**: Trending/popular shows & movies, search, seasons, episodes
- **TmdbClient**: Show details, images, seasons (poster/backdrop CDN)
- **DebridClient**: Real-Debrid instant availability check, magnet add, unrestrict link
- **TorrentSearchClient**: Torrentio addon API for torrent hash discovery
- **ShowsRepository**: Unified repository combining all 4 clients with TMDB enrichment

### Providers (Riverpod)
- Trending/popular shows & movies providers
- Search with debounce
- Show detail (family by trakt ID)
- Episodes (family by trakt ID + season)
- Stream resolution (debrid → direct HTTPS URL)
- API keys state management (SharedPreferences)

### UI
- **ShowsScreen**: Poster grid with category tabs, search bar, TV-friendly nav
- **ShowDetailScreen**: Backdrop hero, metadata chips, season tabs, episode list, play button
- **Settings**: API keys section for Trakt, TMDB, Real-Debrid tokens

### Navigation
- Shows & Movies button added to channels top bar
- Routes: `/shows` and `/shows/:id` in GoRouter

### Resolution Chain
Trakt (discover) → TMDB (enrich) → Torrentio (find hashes) → Real-Debrid (resolve) → media_kit (play)