### PR TITLE
🐛 Add back button to Settings, Providers, and EPG Mappings screens

### DIFF
--- a/lib/features/epg_mapping/epg_mapping_screen.dart
+++ b/lib/features/epg_mapping/epg_mapping_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../data/models/epg.dart';
 import '../providers/provider_manager.dart';
@@ -26,6 +27,10 @@ class _EpgMappingScreenState extends ConsumerState<EpgMappingScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/'),
+        ),
         title: const Text('EPG Mappings'),
         actions: [
           TextButton.icon(

--- a/lib/features/providers/providers_screen.dart
+++ b/lib/features/providers/providers_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
+import 'package:go_router/go_router.dart';
 import '../../data/datasources/local/database.dart' as db;
 import 'add_provider_dialog.dart';
 import 'provider_manager.dart';
@@ -19,7 +19,13 @@ class ProvidersScreen extends ConsumerWidget {
     final providersAsync = ref.watch(_providersStreamProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('IPTV Providers')),
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/'),
+        ),
+        title: const Text('IPTV Providers'),
+      ),
       body: providersAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text('Error: $e')),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../data/datasources/local/database.dart' as db;
 import '../../data/services/epg_refresh_service.dart';
@@ -14,7 +15,13 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/'),
+        ),
+        title: const Text('Settings'),
+      ),
       body: ListView(
         children: [
           _SettingsSection(


### PR DESCRIPTION
Adds a back arrow button to all sub-screens so users can navigate back to channels.