### PR TITLE
🐛 Fix audio regression: remove af filter breaking all streams

### DIFF
--- a/lib/data/datasources/remote/tmdb_client.dart
+++ b/lib/data/datasources/remote/tmdb_client.dart
@@ -77,6 +77,54 @@ class TmdbClient {
         .toList();
   }
 
+  /// Get trending TV shows (day or week)
+  Future<List<TmdbSearchResult>> getTrendingTv({String window = 'day', int page = 1}) async {
+    final response = await _dio.get(
+      '/trending/tv/$window',
+      queryParameters: {'page': page},
+    );
+    final results = response.data['results'] as List;
+    return results
+        .map((e) => TmdbSearchResult.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Get trending movies (day or week)
+  Future<List<TmdbSearchResult>> getTrendingMovie({String window = 'day', int page = 1}) async {
+    final response = await _dio.get(
+      '/trending/movie/$window',
+      queryParameters: {'page': page},
+    );
+    final results = response.data['results'] as List;
+    return results
+        .map((e) => TmdbSearchResult.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Get popular TV shows
+  Future<List<TmdbSearchResult>> getPopularTv({int page = 1}) async {
+    final response = await _dio.get(
+      '/tv/popular',
+      queryParameters: {'page': page},
+    );
+    final results = response.data['results'] as List;
+    return results
+        .map((e) => TmdbSearchResult.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Get popular movies
+  Future<List<TmdbSearchResult>> getPopularMovie({int page = 1}) async {
+    final response = await _dio.get(
+      '/movie/popular',
+      queryParameters: {'page': page},
+    );
+    final results = response.data['results'] as List;
+    return results
+        .map((e) => TmdbSearchResult.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
   /// Find by external ID (e.g., IMDB ID)
   Future<TmdbShowDetail?> findByImdbId(String imdbId, {bool isMovie = false}) async {
     final response = await _dio.get(

--- a/lib/features/player/player_service.dart
+++ b/lib/features/player/player_service.dart
@@ -34,25 +34,18 @@ class PlayerService {
   Future<void> _initPlayer(Player p) async {
     final np = p.platform;
     if (np is native_player.NativePlayer) {
-      // Exclude AudioToolbox decoders which silently fail on eac3/ac3
-      // surround streams on macOS — force FFmpeg software decoders instead
-      await np.setProperty('ad', '-ac3_at,-eac3_at,-aac_at');
-      // Force audio through resampling filter to ensure compatible output
-      // Must use lavfi=[] wrapper for ffmpeg filters in mpv
-      await np.setProperty('af', 'lavfi=[aformat=channel_layouts=stereo]');
+      // Exclude only eac3/ac3 AudioToolbox decoders which silently fail
+      // on surround streams — keep aac_at since most streams use AAC fine
+      await np.setProperty('ad', '-ac3_at,-eac3_at');
       // Downmix surround to stereo for output compatibility
       await np.setProperty('audio-channels', 'stereo');
       // Normalize volume when downmixing surround to stereo
       await np.setProperty('audio-normalize-downmix', 'yes');
       // Disable SPDIF passthrough which can cause silent output
       await np.setProperty('audio-spdif', '');
-      // Ensure CoreAudio output is used
-      await np.setProperty('ao', 'coreaudio');
       // Volume
       await np.setProperty('volume', '100');
       await np.setProperty('mute', 'no');
-      // Verbose audio logging to debug remaining issues
-      await np.setProperty('msg-level', 'all=warn,ao=v,ad=v,af=v');
     }
     await p.setVolume(100);
     _playerReady = true;


### PR DESCRIPTION
The lavfi audio filter and -aac_at exclusion broke audio on all channels. Simplified to only exclude -ac3_at,-eac3_at.