### PR TITLE
🐛 Fix TMDB 401: api_key dropped on per-request queryParameters

### DIFF
--- a/lib/data/datasources/remote/tmdb_client.dart
+++ b/lib/data/datasources/remote/tmdb_client.dart
@@ -16,8 +16,13 @@ class TmdbClient {
     _dio.options
       ..baseUrl = _baseUrl
       ..connectTimeout = const Duration(seconds: 10)
-      ..receiveTimeout = const Duration(seconds: 15)
-      ..queryParameters = {'api_key': apiKey};
+      ..receiveTimeout = const Duration(seconds: 15);
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) {
+        options.queryParameters['api_key'] = apiKey;
+        handler.next(options);
+      },
+    ));
   }
 
   /// Build a full image URL from a TMDB file path


### PR DESCRIPTION
Dio's `options.queryParameters` gets overridden (not merged) when individual requests pass their own `queryParameters`. This caused every TMDB call with extra params (search, trending, popular) to lose the `api_key`, resulting in 401 errors. Fixed by using an interceptor to inject `api_key` into every request.