### PR TITLE
✨ Add DLNA/UPnP screen casting to Apple TV, Android TV, Smart TVs

### DIFF
--- a/lib/features/casting/cast_dialog.dart
+++ b/lib/features/casting/cast_dialog.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'cast_service.dart';
+
+/// Shows a dialog to discover and select a cast target device.
+Future<CastDevice?> showCastDialog(BuildContext context, WidgetRef ref) async {
+  return showDialog<CastDevice>(
+    context: context,
+    builder: (ctx) => _CastDialog(ref: ref),
+  );
+}
+
+class _CastDialog extends StatefulWidget {
+  final WidgetRef ref;
+  const _CastDialog({required this.ref});
+
+  @override
+  State<_CastDialog> createState() => _CastDialogState();
+}
+
+class _CastDialogState extends State<_CastDialog> {
+  late final CastService _castService;
+  StreamSubscription? _sub;
+  List<CastDevice> _devices = [];
+  bool _scanning = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _castService = widget.ref.read(castServiceProvider);
+    _startScan();
+  }
+
+  void _startScan() async {
+    _sub = _castService.devicesStream.listen((devices) {
+      if (mounted) setState(() => _devices = devices);
+    });
+    await _castService.startDiscovery();
+    // Stop auto-scanning after 15 seconds
+    Future.delayed(const Duration(seconds: 15), () {
+      if (mounted) setState(() => _scanning = false);
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: const Color(0xFF1A1A2E),
+      title: Row(
+        children: [
+          const Icon(Icons.cast_rounded, color: Colors.amber, size: 22),
+          const SizedBox(width: 8),
+          const Text('Cast to Device', style: TextStyle(color: Colors.white, fontSize: 16)),
+          const Spacer(),
+          if (_scanning)
+            const SizedBox(
+              width: 16, height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2, color: Colors.amber),
+            ),
+        ],
+      ),
+      content: SizedBox(
+        width: 320,
+        height: 300,
+        child: _devices.isEmpty
+            ? Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      _scanning ? Icons.radar_rounded : Icons.cast_connected_rounded,
+                      size: 48,
+                      color: Colors.white24,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      _scanning
+                          ? 'Scanning for devices…'
+                          : 'No devices found.\nMake sure devices are on the same network.',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(color: Colors.white54, fontSize: 13),
+                    ),
+                    if (!_scanning) ...[
+                      const SizedBox(height: 16),
+                      TextButton.icon(
+                        onPressed: () {
+                          setState(() { _scanning = true; _devices.clear(); });
+                          _startScan();
+                        },
+                        icon: const Icon(Icons.refresh_rounded, size: 16),
+                        label: const Text('Scan Again'),
+                        style: TextButton.styleFrom(foregroundColor: Colors.amber),
+                      ),
+                    ],
+                  ],
+                ),
+              )
+            : ListView.builder(
+                itemCount: _devices.length,
+                itemBuilder: (ctx, i) {
+                  final device = _devices[i];
+                  final isActive = _castService.activeDevice?.id == device.id;
+                  return ListTile(
+                    leading: Icon(
+                      _iconForDevice(device),
+                      color: isActive ? Colors.amber : Colors.white54,
+                      size: 28,
+                    ),
+                    title: Text(
+                      device.name,
+                      style: TextStyle(
+                        color: isActive ? Colors.amber : Colors.white,
+                        fontSize: 14,
+                        fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
+                      ),
+                    ),
+                    subtitle: Text(
+                      device.type.toUpperCase(),
+                      style: const TextStyle(color: Colors.white38, fontSize: 11),
+                    ),
+                    trailing: isActive
+                        ? const Icon(Icons.check_circle_rounded, color: Colors.amber, size: 20)
+                        : null,
+                    onTap: () => Navigator.of(context).pop(device),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                    hoverColor: Colors.white.withValues(alpha: 0.05),
+                  );
+                },
+              ),
+      ),
+      actions: [
+        if (_castService.isCasting)
+          TextButton.icon(
+            onPressed: () async {
+              await _castService.stopCasting();
+              if (context.mounted) Navigator.of(context).pop();
+            },
+            icon: const Icon(Icons.cast_connected_rounded, size: 16),
+            label: const Text('Stop Casting'),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+          ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel', style: TextStyle(color: Colors.white54)),
+        ),
+      ],
+    );
+  }
+
+  IconData _iconForDevice(CastDevice device) {
+    final name = device.name.toLowerCase();
+    if (name.contains('apple tv') || name.contains('airplay')) {
+      return Icons.tv_rounded;
+    } else if (name.contains('chromecast') || name.contains('google')) {
+      return Icons.cast_rounded;
+    } else if (name.contains('samsung') || name.contains('lg') || name.contains('sony') || name.contains('tv')) {
+      return Icons.tv_rounded;
+    } else if (name.contains('sonos') || name.contains('speaker')) {
+      return Icons.speaker_rounded;
+    }
+    return Icons.devices_rounded;
+  }
+}

--- a/lib/features/casting/cast_service.dart
+++ b/lib/features/casting/cast_service.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+
+import 'package:dlna_dart/dlna.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logger/logger.dart';
+
+final _log = Logger(printer: SimplePrinter());
+
+/// Represents a discovered cast target on the local network.
+class CastDevice {
+  final String id;
+  final String name;
+  final String type; // 'dlna'
+  final DLNADevice? dlnaDevice;
+
+  CastDevice({required this.id, required this.name, required this.type, this.dlnaDevice});
+
+  @override
+  String toString() => '$name ($type)';
+}
+
+/// Manages device discovery and casting of IPTV streams via DLNA/UPnP.
+class CastService {
+  DLNAManager? _dlnaManager;
+  DeviceManager? _deviceManager;
+  StreamSubscription? _deviceSub;
+
+  final _devicesController = StreamController<List<CastDevice>>.broadcast();
+  final Map<String, CastDevice> _devices = {};
+
+  CastDevice? _activeDevice;
+  String? _activeUrl;
+  bool _isCasting = false;
+
+  /// Stream of discovered cast devices.
+  Stream<List<CastDevice>> get devicesStream => _devicesController.stream;
+
+  /// Currently available devices.
+  List<CastDevice> get devices => _devices.values.toList();
+
+  /// Whether we are actively casting.
+  bool get isCasting => _isCasting;
+
+  /// The device we are casting to.
+  CastDevice? get activeDevice => _activeDevice;
+
+  /// Start scanning for DLNA/UPnP devices on the local network.
+  Future<void> startDiscovery() async {
+    await stopDiscovery();
+    _devices.clear();
+    _dlnaManager = DLNAManager();
+    try {
+      _deviceManager = await _dlnaManager!.start(reusePort: true);
+      _deviceSub = _deviceManager!.devices.stream.listen((deviceMap) {
+        _devices.clear();
+        for (final entry in deviceMap.entries) {
+          final dlna = entry.value;
+          final name = dlna.info.friendlyName;
+          _devices[entry.key] = CastDevice(
+            id: entry.key,
+            name: name.isNotEmpty ? name : 'Unknown Device',
+            type: 'dlna',
+            dlnaDevice: dlna,
+          );
+        }
+        _devicesController.add(_devices.values.toList());
+      });
+      _log.i('DLNA discovery started');
+    } catch (e) {
+      _log.e('DLNA discovery failed: $e');
+    }
+  }
+
+  /// Stop scanning.
+  Future<void> stopDiscovery() async {
+    _deviceSub?.cancel();
+    _deviceSub = null;
+    _dlnaManager?.stop();
+    _dlnaManager = null;
+    _deviceManager = null;
+  }
+
+  /// Cast a stream URL to the given device.
+  Future<bool> castTo(CastDevice device, String url, {String title = ''}) async {
+    try {
+      if (device.dlnaDevice != null) {
+        await device.dlnaDevice!.setUrl(url, title: title);
+        await device.dlnaDevice!.play();
+        _activeDevice = device;
+        _activeUrl = url;
+        _isCasting = true;
+        _log.i('Casting to ${device.name}: $url');
+        return true;
+      }
+      return false;
+    } catch (e) {
+      _log.e('Cast failed: $e');
+      return false;
+    }
+  }
+
+  /// Stop casting on the active device.
+  Future<void> stopCasting() async {
+    try {
+      if (_activeDevice?.dlnaDevice != null) {
+        await _activeDevice!.dlnaDevice!.stop();
+      }
+    } catch (e) {
+      _log.e('Stop cast error: $e');
+    }
+    _activeDevice = null;
+    _activeUrl = null;
+    _isCasting = false;
+  }
+
+  /// Pause playback on the active device.
+  Future<void> pause() async {
+    try {
+      await _activeDevice?.dlnaDevice?.pause();
+    } catch (e) {
+      _log.e('Cast pause error: $e');
+    }
+  }
+
+  /// Resume playback on the active device.
+  Future<void> resume() async {
+    try {
+      await _activeDevice?.dlnaDevice?.play();
+    } catch (e) {
+      _log.e('Cast resume error: $e');
+    }
+  }
+
+  /// Set volume (0-100) on the active device.
+  Future<void> setVolume(int volume) async {
+    try {
+      await _activeDevice?.dlnaDevice?.volume(volume.clamp(0, 100));
+    } catch (e) {
+      _log.e('Cast volume error: $e');
+    }
+  }
+
+  /// Switch channel: cast a new URL to the same device.
+  Future<bool> switchChannel(String url, {String title = ''}) async {
+    if (_activeDevice == null) return false;
+    return castTo(_activeDevice!, url, title: title);
+  }
+
+  void dispose() {
+    stopCasting();
+    stopDiscovery();
+    _devicesController.close();
+  }
+}
+
+/// Riverpod provider for the cast service (singleton).
+final castServiceProvider = Provider<CastService>((ref) {
+  final service = CastService();
+  ref.onDispose(() => service.dispose());
+  return service;
+});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -297,6 +297,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  dlna_dart:
+    dependency: "direct main"
+    description:
+      name: dlna_dart
+      sha256: "8a4f0e4f378615c99f2af679dc9f0c72fe4a0fb2f3eea96b637fe691dfcf0649"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   drift:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   cached_network_image: ^3.4.1
   shimmer: ^3.0.0
   flutter_staggered_grid_view: ^0.7.0
+  dlna_dart: ^0.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Screen Casting Support

Adds DLNA/UPnP device discovery and screen casting so users can cast IPTV streams to:
- Apple TV
- Android TV / Google TV
- Samsung Smart TVs
- LG Smart TVs
- Sony Smart TVs
- Sonos speakers
- Any DLNA/UPnP-compatible renderer

### Changes
- **cast_service.dart** — DLNA discovery via SSDP multicast, cast/pause/resume/stop/volume/channel-switch
- **cast_dialog.dart** — Device picker dialog with auto-scan, smart device icons, stop casting button
- **player_screen.dart** — Cast button in fullscreen player overlay controls
- **channels_screen.dart** — Cast button in top bar (turns amber when actively casting)
- **pubspec.yaml** — Added `dlna_dart` dependency

### Testing
- macOS release build passes ✓
- 101.9MB app bundle