### PR TITLE
🌱 Unlock pro tier by default

### DIFF
--- a/lib/core/feature_gate.dart
+++ b/lib/core/feature_gate.dart
@@ -28,7 +28,7 @@ enum AppTier { free, pro }
 /// so changing the logic later (e.g. adding trials, per-feature
 /// purchases) only requires editing this one file.
 class FeatureGate {
-  static AppTier _currentTier = AppTier.free;
+  static AppTier _currentTier = AppTier.pro;
 
   static AppTier get currentTier => _currentTier;
   static bool get isPro => _currentTier == AppTier.pro;


### PR DESCRIPTION
Sets default tier to Pro so provider limit (and all other gates) are removed.