### PR TITLE
🐛 Fix free TV providers not showing in sidebar

### DIFF
--- a/lib/features/channels/channels_screen.dart
+++ b/lib/features/channels/channels_screen.dart
@@ -809,7 +809,10 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
           IconButton(
             icon: const Icon(Icons.dns_rounded, color: Colors.white70),
             tooltip: 'Providers',
-            onPressed: () => context.push('/providers'),
+            onPressed: () async {
+              await context.push('/providers');
+              if (mounted) _loadChannels();
+            },
           ),
           IconButton(
             icon: const Icon(Icons.link_rounded, color: Colors.white70),

--- a/lib/features/providers/providers_screen.dart
+++ b/lib/features/providers/providers_screen.dart
@@ -298,7 +298,18 @@ class _FreeTvProviderTile extends ConsumerWidget {
           overflow: TextOverflow.ellipsis,
         ),
         trailing: isAdded
-            ? const Icon(Icons.check_circle, color: Colors.greenAccent, size: 28)
+            ? Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.check_circle, color: Colors.greenAccent, size: 22),
+                  const SizedBox(width: 4),
+                  IconButton(
+                    icon: const Icon(Icons.refresh_rounded, color: Colors.white38, size: 20),
+                    tooltip: 'Re-sync',
+                    onPressed: () => _addProvider(context, ref),
+                  ),
+                ],
+              )
             : IconButton(
                 icon: const Icon(Icons.add_circle_outline, color: accent, size: 28),
                 onPressed: () => _addProvider(context, ref),
@@ -317,7 +328,7 @@ class _FreeTvProviderTile extends ConsumerWidget {
       );
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('${freeProvider.name} added — loading channels...')),
+        SnackBar(content: Text('${freeProvider.name} ${isAdded ? "refreshed" : "added"} — loading channels...')),
       );
     } on ProviderLimitException catch (e) {
       if (!context.mounted) return;


### PR DESCRIPTION
Two fixes:
1. Reload channels when returning from Providers screen so new providers appear in sidebar immediately
2. Add re-sync button on already-added free providers to update URL and refresh channels (fixes stale 404 URLs)