### PR TITLE
✨ Show provider name on channels, fix sidebar defaults

### DIFF
--- a/lib/features/providers/providers_screen.dart
+++ b/lib/features/providers/providers_screen.dart
@@ -22,7 +22,7 @@ class ProvidersScreen extends ConsumerWidget {
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.go('/'),
+          onPressed: () => context.pop(),
         ),
         title: const Text('IPTV Providers'),
       ),


### PR DESCRIPTION
- Provider name shown on channel rows in both list and guide views
- Removed meaningless channel numbers
- Sidebar sections default to collapsed (except Favorites)
- Live sidebar reload via database stream watchers
- Fixed providers screen back button (pop instead of go)