### PR TITLE
🐛 Auto-scroll season tabs to selected season

### DIFF
--- a/lib/data/repositories/shows_repository.dart
+++ b/lib/data/repositories/shows_repository.dart
@@ -287,14 +287,14 @@ class ShowsRepository {
   }
 
   /// Resolve a specific torrent via Real-Debrid (add magnet → wait → stream URL)
-  Future<ResolvedStream?> resolveMagnet(String magnetUrl) async {
-    if (_debrid == null) return null;
-    try {
-      return await _debrid.resolveFromMagnet(magnetUrl);
-    } catch (e) {
-      _log.e('Failed to resolve magnet: $e');
-      return null;
+  Future<ResolvedStream?> resolveMagnet(
+    String magnetUrl, {
+    void Function(String status, int progress)? onProgress,
+  }) async {
+    if (_debrid == null) {
+      throw Exception('No Real-Debrid API key configured');
     }
+    return await _debrid.resolveFromMagnet(magnetUrl, onProgress: onProgress);
   }
 
   /// Enrich a list of shows with TMDB poster/backdrop URLs


### PR DESCRIPTION
Shows with many seasons (e.g. Gold Rush with 14+) had the selected latest season off-screen. Now auto-scrolls the season chip bar to the selected season on load.