### PR TITLE
🐛 Fix guide time ruler Row overflow

### DIFF
--- a/lib/features/channels/channels_screen.dart
+++ b/lib/features/channels/channels_screen.dart
@@ -2122,6 +2122,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
                   child: SizedBox(
                     width: totalWidth,
                     child: Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: List.generate(24, (hour) {
                         final width = 60 * _pixelsPerMinute;
                         return SizedBox(


### PR DESCRIPTION
Fix RenderFlex overflow by 1092px on the guide time ruler Row. Added mainAxisSize: MainAxisSize.min.