### PR TITLE
🐛 Fix EPG guide, failover matching, 24/7 channels, time format

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../data/datasources/local/database.dart' as db;
 import '../../data/services/backup_service.dart';
@@ -169,6 +170,12 @@ class SettingsScreen extends ConsumerWidget {
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () {},
               ),
+            ],
+          ),
+          _SettingsSection(
+            title: 'Display',
+            children: [
+              _TimeFormatTile(),
             ],
           ),
           _SettingsSection(
@@ -575,6 +582,40 @@ class _SettingsSection extends StatelessWidget {
         ),
         ...children,
       ],
+    );
+  }
+}
+
+class _TimeFormatTile extends StatefulWidget {
+  @override
+  State<_TimeFormatTile> createState() => _TimeFormatTileState();
+}
+
+class _TimeFormatTileState extends State<_TimeFormatTile> {
+  bool _use24Hour = false;
+
+  @override
+  void initState() {
+    super.initState();
+    SharedPreferences.getInstance().then((prefs) {
+      if (mounted) {
+        setState(() => _use24Hour = prefs.getBool('use_24_hour_time') ?? false);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      secondary: const Icon(Icons.schedule_rounded),
+      title: const Text('24-Hour Time'),
+      subtitle: Text(_use24Hour ? '14:30' : '2:30 PM'),
+      value: _use24Hour,
+      onChanged: (value) async {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setBool('use_24_hour_time', value);
+        setState(() => _use24Hour = value);
+      },
     );
   }
 }


### PR DESCRIPTION
## EPG Guide
- Programme blocks positioned absolutely (Stack) so they align with time ruler
- Now-line: subtle white vertical line at current time across all channel rows
- Current time label shown in ruler bar
- Auto-snap: after 10s idle, scrolls back to current time (30 min behind visible)
- Time ruler and all times respect 12/24h setting

## 24/7 Channels
- Skip fuzzy EPG matching for 24/7 channels — only exact tvg-id match allowed
- Prevents wrong EPG data (e.g. 'This Old House' showing on '24/7 Pretty Little Liars')
- Strip '24/7' prefix in channel name cleaning

## Failover
- Match by normalized channel name instead of group title
- Priority: same name different provider > same name same provider > fuzzy name match
- Strips HD/FHD/country prefixes for better name comparison

## Settings
- New 'Display' section with 24-hour time toggle
- Persisted via SharedPreferences

## Other
- Instant channel rename via copyWith (no full reload)
- Skip re-selecting already-selected channel