### PR TITLE
🐛 Fix EPG timeshift fetch window

### DIFF
--- a/lib/features/channels/channels_screen.dart
+++ b/lib/features/channels/channels_screen.dart
@@ -2601,11 +2601,14 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
       );
     }
 
+    final shiftHours = _epgTimeshifts[channel.id] ?? 0;
+    final fetchShift = Duration(hours: shiftHours);
+
     return FutureBuilder<List<db.EpgProgramme>>(
       future: database.getProgrammes(
         epgChannelId: epgId,
-        start: dayStart,
-        end: dayEnd,
+        start: dayStart.subtract(fetchShift),
+        end: dayEnd.subtract(fetchShift),
       ),
       builder: (context, snapshot) {
         if (!snapshot.hasData || snapshot.data!.isEmpty) {


### PR DESCRIPTION
Fetch programmes from shifted time window so timeshifted channels show data correctly in the guide.