### PR TITLE
🐛 Fix logo resolver: normalization was stripping channel names

### DIFF
--- a/lib/features/providers/provider_manager.dart
+++ b/lib/features/providers/provider_manager.dart
@@ -141,7 +141,7 @@ class ProviderManager {
         }
       }
       for (final ch in needsLogo.toList()) {
-        final stripped = ch.name.toLowerCase().replaceAll(RegExp(r'^[a-z]{2}[-:]?\s*\|?\s*'), '');
+        final stripped = ch.name.toLowerCase().replaceAll(RegExp(r'^[a-z]{2}[-]?[a-z]?\|\s*'), '').replaceAll(RegExp(r'^[a-z]{2}:\s+'), '');
         final icon = epgIconMap[ch.name.toLowerCase()] ?? epgIconMap[stripped];
         if (icon != null) {
           await _db.updateChannelLogo(ch.id, icon);


### PR DESCRIPTION
The prefix regex `^[a-z]{2}[-:]?\s*\|?\s*` matched the first 2 chars of ALL names, turning CBS→s, ABC→c, Food Network→od-network.

Fix: only strip when an explicit separator is present (`US-P|`, `UK|`, `CA:`).

Also:
- Add `usa-`/`us-` prefix stripping as alias strategy  
- Prefer `-logo` variants over `-nfl`/`-news` in prefix matching