### PR TITLE
✨ Add CI/CD: nightly and weekly multi-platform releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,222 @@
+# Reusable build workflow for all platforms
+name: Build All Platforms
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'Tag name for the release'
+        required: true
+        type: string
+      release_name:
+        description: 'Display name for the release'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark as pre-release'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  # ─── Android ────────────────────────────────────────────────────────
+  build-android:
+    name: Android (APK + AAB)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Build AAB
+        run: flutter build appbundle --release
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+
+      - name: Upload AAB
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-aab
+          path: build/app/outputs/bundle/release/app-release.aab
+
+  # ─── iOS ────────────────────────────────────────────────────────────
+  build-ios:
+    name: iOS (IPA)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build iOS (no codesign)
+        run: flutter build ios --release --no-codesign
+
+      - name: Create unsigned IPA
+        run: |
+          cd build/ios/iphoneos
+          mkdir -p Payload
+          cp -r Runner.app Payload/
+          zip -r clubtivi-ios-unsigned.ipa Payload
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa
+          path: build/ios/iphoneos/clubtivi-ios-unsigned.ipa
+
+  # ─── macOS ──────────────────────────────────────────────────────────
+  build-macos:
+    name: macOS (DMG)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build macOS
+        run: flutter build macos --release
+
+      - name: Create DMG
+        run: |
+          APP_PATH="build/macos/Build/Products/Release/clubtivi.app"
+          DMG_NAME="clubtivi-macos.dmg"
+          hdiutil create -volname "clubTivi" -srcfolder "$APP_PATH" -ov -format UDZO "$DMG_NAME"
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg
+          path: clubtivi-macos.dmg
+
+  # ─── Windows ────────────────────────────────────────────────────────
+  build-windows:
+    name: Windows (ZIP)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Windows
+        run: flutter build windows --release
+
+      - name: Create ZIP
+        run: Compress-Archive -Path "build\windows\x64\runner\Release\*" -DestinationPath "clubtivi-windows.zip"
+
+      - name: Upload ZIP
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-zip
+          path: clubtivi-windows.zip
+
+  # ─── Linux ──────────────────────────────────────────────────────────
+  build-linux:
+    name: Linux (tar.gz)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config \
+            libgtk-3-dev liblzma-dev libstdc++-12-dev \
+            libmpv-dev
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Linux
+        run: flutter build linux --release
+
+      - name: Create tarball
+        run: |
+          cd build/linux/x64/release
+          tar czf ../../../../clubtivi-linux-x64.tar.gz bundle/
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-tar
+          path: clubtivi-linux-x64.tar.gz
+
+  # ─── Create Release ────────────────────────────────────────────────
+  create-release:
+    name: Create GitHub Release
+    needs: [build-android, build-ios, build-macos, build-windows, build-linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release
+          cp artifacts/android-apk/app-release.apk       release/clubtivi-android.apk
+          cp artifacts/android-aab/app-release.aab        release/clubtivi-android.aab
+          cp artifacts/ios-ipa/clubtivi-ios-unsigned.ipa   release/clubtivi-ios-unsigned.ipa
+          cp artifacts/macos-dmg/clubtivi-macos.dmg       release/clubtivi-macos.dmg
+          cp artifacts/windows-zip/clubtivi-windows.zip   release/clubtivi-windows.zip
+          cp artifacts/linux-tar/clubtivi-linux-x64.tar.gz release/clubtivi-linux-x64.tar.gz
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          name: ${{ inputs.release_name }}
+          prerelease: ${{ inputs.prerelease }}
+          generate_release_notes: true
+          files: release/*

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,65 @@
+# Nightly release — runs every day at 2:00 AM UTC
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch: # allow manual trigger
+
+concurrency:
+  group: nightly-release
+  cancel-in-progress: true
+
+jobs:
+  check-changes:
+    name: Check for new commits
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+      short_sha: ${{ steps.check.outputs.short_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for commits in last 24h
+        id: check
+        run: |
+          SINCE=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-24H '+%Y-%m-%dT%H:%M:%SZ')
+          COUNT=$(git log --since="$SINCE" --oneline | wc -l | tr -d ' ')
+          SHA=$(git rev-parse --short HEAD)
+          echo "short_sha=$SHA" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" -gt 0 ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true'
+    uses: ./.github/workflows/build.yml
+    with:
+      release_tag: nightly-${{ needs.check-changes.outputs.short_sha }}
+      release_name: "🌙 Nightly — ${{ needs.check-changes.outputs.short_sha }}"
+      prerelease: true
+
+  cleanup:
+    name: Clean up old nightlies
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete old nightly releases (keep last 7)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release list --limit 100 --json tagName,isPrerelease \
+            -q '[.[] | select(.isPrerelease and (.tagName | startswith("nightly-")))] | sort_by(.tagName) | reverse | .[7:][] | .tagName' \
+          | while read -r tag; do
+              echo "Deleting old nightly: $tag"
+              gh release delete "$tag" --yes --cleanup-tag
+            done

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,56 @@
+# Weekly release — runs every Sunday at 6:00 AM UTC
+name: Weekly Release
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'
+  workflow_dispatch: # allow manual trigger
+
+concurrency:
+  group: weekly-release
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Prepare release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      name: ${{ steps.tag.outputs.name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate weekly tag
+        id: tag
+        run: |
+          WEEK=$(date -u '+%Y.%W')
+          echo "tag=weekly-${WEEK}" >> "$GITHUB_OUTPUT"
+          echo "name=📦 Weekly ${WEEK}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    uses: ./.github/workflows/build.yml
+    with:
+      release_tag: ${{ needs.prepare.outputs.tag }}
+      release_name: ${{ needs.prepare.outputs.name }}
+      prerelease: false
+
+  cleanup:
+    name: Clean up old weeklies
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete old weekly releases (keep last 8)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release list --limit 100 --json tagName,isPrerelease \
+            -q '[.[] | select(.isPrerelease == false and (.tagName | startswith("weekly-")))] | sort_by(.tagName) | reverse | .[8:][] | .tagName' \
+          | while read -r tag; do
+              echo "Deleting old weekly: $tag"
+              gh release delete "$tag" --yes --cleanup-tag
+            done


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI/CD for automated releases across all 5 platforms.

### Workflows

| Workflow | Schedule | Platforms | Retention |
|---|---|---|---|
| **Nightly** | Daily 2AM UTC | All 5 | Last 7 |
| **Weekly** | Sundays 6AM UTC | All 5 | Last 8 |

### Build Artifacts per Release

| Platform | Format |
|---|---|
| Android | APK + AAB |
| iOS | Unsigned IPA |
| macOS | DMG |
| Windows | ZIP |
| Linux x64 | tar.gz |

### Features
- Reusable `build.yml` called by both nightly and weekly
- Nightly skips if no commits in last 24h
- Both support `workflow_dispatch` for manual triggers
- Auto-cleanup of old releases
- Auto-generated release notes from commits

### Notes
- iOS builds are unsigned (no Apple Developer cert configured yet)
- Android uses debug signing (TODO in build.gradle.kts for release keystore)
- Both can be added later via GitHub Secrets