### PR TITLE
🐛 Fix ESC navigation, guide EPG data, player controls, debug overlay

### DIFF
--- a/lib/features/epg_mapping/epg_mapping_screen.dart
+++ b/lib/features/epg_mapping/epg_mapping_screen.dart
@@ -29,7 +29,14 @@ class _EpgMappingScreenState extends ConsumerState<EpgMappingScreen> {
     return CallbackShortcuts(
       bindings: {
         const SingleActivator(LogicalKeyboardKey.escape): () {
-          context.go('/settings');
+          final pf = FocusManager.instance.primaryFocus;
+          if (pf?.context?.findAncestorWidgetOfExactType<EditableText>() != null) {
+            pf!.unfocus();
+            return;
+          }
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            context.go('/settings');
+          });
         },
       },
       child: Focus(

--- a/lib/features/guide/guide_screen.dart
+++ b/lib/features/guide/guide_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:go_router/go_router.dart';
+
 import '../../core/fuzzy_match.dart';
 import '../../data/datasources/local/database.dart' as db;
 import '../providers/provider_manager.dart';
@@ -24,9 +26,18 @@ class _GuideScreenState extends ConsumerState<GuideScreen> {
   /// Pixels per minute for the timeline.
   static const _pixelsPerMinute = 4.0;
 
+  /// Total width of the 24-hour timeline.
+  static double get _totalWidth => 24 * 60 * _pixelsPerMinute;
+
+  // EPG mapping data (loaded once)
+  Map<String, String> _epgMappings = {};
+  Set<String> _validEpgChannelIds = {};
+  bool _mappingsLoaded = false;
+
   @override
   void initState() {
     super.initState();
+    _loadMappings();
     // Scroll to "now" on load
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_scrollController.hasClients) {
@@ -34,6 +45,41 @@ class _GuideScreenState extends ConsumerState<GuideScreen> {
         _scrollController.jumpTo(nowMinutes * _pixelsPerMinute - 100);
       }
     });
+  }
+
+  Future<void> _loadMappings() async {
+    final database = ref.read(databaseProvider);
+    final mappings = await database.getAllMappings();
+    final epgMap = <String, String>{};
+    for (final m in mappings) {
+      epgMap[m.channelId] = '${m.epgSourceId}_${m.epgChannelId}';
+    }
+    final epgSources = await database.getAllEpgSources();
+    final validIds = <String>{};
+    for (final src in epgSources) {
+      final chs = await database.getEpgChannelsForSource(src.id);
+      for (final ch in chs) {
+        validIds.add(ch.id);
+      }
+    }
+    if (!mounted) return;
+    setState(() {
+      _epgMappings = epgMap;
+      _validEpgChannelIds = validIds;
+      _mappingsLoaded = true;
+    });
+  }
+
+  /// Resolve a channel to its EPG channel ID for programme lookup.
+  String? _resolveEpgId(db.Channel channel) {
+    final mapped = _epgMappings[channel.id];
+    if (mapped != null && mapped.isNotEmpty) return mapped;
+    if (channel.tvgId != null &&
+        channel.tvgId!.isNotEmpty &&
+        _validEpgChannelIds.contains(channel.tvgId)) {
+      return channel.tvgId!;
+    }
+    return null;
   }
 
   @override
@@ -46,6 +92,25 @@ class _GuideScreenState extends ConsumerState<GuideScreen> {
 
   void _handleKeyEvent(KeyEvent event) {
     if (event is! KeyDownEvent) return;
+    // Don't intercept keys when a text field is focused
+    final primaryFocus = FocusManager.instance.primaryFocus;
+    if (primaryFocus?.context?.findAncestorWidgetOfExactType<EditableText>() != null) {
+      if (event.logicalKey == LogicalKeyboardKey.escape) {
+        primaryFocus!.unfocus();
+      }
+      return;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.escape) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (context.canPop()) {
+          context.pop();
+        } else {
+          context.go('/');
+        }
+      });
+      return;
+    }
     if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
       _scrollController.animateTo(
         (_scrollController.offset - 200).clamp(0.0, _scrollController.position.maxScrollExtent),
@@ -167,13 +232,15 @@ class _GuideScreenState extends ConsumerState<GuideScreen> {
                       itemCount: channels.length,
                       itemBuilder: (context, index) {
                         final channel = channels[index];
+                        final epgId = _mappingsLoaded ? _resolveEpgId(channel) : null;
                         return _ChannelGuideRow(
                           channelName: channel.name,
                           channelLogo: channel.tvgLogo,
                           scrollController: _scrollController,
                           database: database,
-                          channelId: channel.id,
+                          epgChannelId: epgId,
                           focusDate: _focusTime,
+                          pixelsPerMinute: _pixelsPerMinute,
                         );
                       },
                     );
@@ -227,25 +294,76 @@ class _TimeRuler extends StatelessWidget {
   }
 }
 
-class _ChannelGuideRow extends StatelessWidget {
+class _ChannelGuideRow extends StatefulWidget {
   final String channelName;
   final String? channelLogo;
   final ScrollController scrollController;
   final db.AppDatabase database;
-  final String channelId;
+  final String? epgChannelId;
   final DateTime focusDate;
+  final double pixelsPerMinute;
 
   const _ChannelGuideRow({
     required this.channelName,
     this.channelLogo,
     required this.scrollController,
     required this.database,
-    required this.channelId,
+    this.epgChannelId,
     required this.focusDate,
+    required this.pixelsPerMinute,
   });
 
   @override
+  State<_ChannelGuideRow> createState() => _ChannelGuideRowState();
+}
+
+class _ChannelGuideRowState extends State<_ChannelGuideRow> {
+  List<db.EpgProgramme>? _programmes;
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProgrammes();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ChannelGuideRow old) {
+    super.didUpdateWidget(old);
+    if (old.epgChannelId != widget.epgChannelId ||
+        old.focusDate != widget.focusDate) {
+      _loadProgrammes();
+    }
+  }
+
+  Future<void> _loadProgrammes() async {
+    if (widget.epgChannelId == null) {
+      if (mounted) setState(() => _programmes = []);
+      return;
+    }
+    setState(() => _loading = true);
+    final dayStart = DateTime(
+        widget.focusDate.year, widget.focusDate.month, widget.focusDate.day);
+    final dayEnd = dayStart.add(const Duration(hours: 24));
+    try {
+      final progs = await widget.database.getProgrammes(
+        epgChannelId: widget.epgChannelId!,
+        start: dayStart,
+        end: dayEnd,
+      );
+      if (mounted) setState(() { _programmes = progs; _loading = false; });
+    } catch (_) {
+      if (mounted) setState(() { _programmes = []; _loading = false; });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final ppm = widget.pixelsPerMinute;
+    final dayStart = DateTime(
+        widget.focusDate.year, widget.focusDate.month, widget.focusDate.day);
+    final now = DateTime.now();
+
     return SizedBox(
       height: 56,
       child: Row(
@@ -255,33 +373,109 @@ class _ChannelGuideRow extends StatelessWidget {
             width: 120,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Text(
-                channelName,
-                style: const TextStyle(fontSize: 12),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
+              child: Row(
+                children: [
+                  if (widget.channelLogo != null && widget.channelLogo!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 6),
+                      child: Image.network(widget.channelLogo!, width: 24, height: 24,
+                        errorBuilder: (_, __, ___) => const Icon(Icons.tv, size: 18, color: Colors.white24)),
+                    ),
+                  Expanded(
+                    child: Text(widget.channelName,
+                      style: const TextStyle(fontSize: 11),
+                      maxLines: 2, overflow: TextOverflow.ellipsis),
+                  ),
+                ],
               ),
             ),
           ),
-          // Programme blocks (placeholder — populated when EPG data exists)
+          // Programme timeline
           Expanded(
-            child: Container(
-              margin: const EdgeInsets.symmetric(vertical: 2),
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.03),
-                borderRadius: BorderRadius.circular(4),
-              ),
-              child: const Center(
-                child: Text(
-                  'No EPG data',
-                  style: TextStyle(fontSize: 10, color: Colors.white24),
-                ),
+            child: SingleChildScrollView(
+              controller: widget.scrollController,
+              scrollDirection: Axis.horizontal,
+              child: SizedBox(
+                width: 24 * 60 * ppm,
+                height: 52,
+                child: _loading
+                    ? const SizedBox.shrink()
+                    : (_programmes == null || _programmes!.isEmpty)
+                        ? Container(
+                            margin: const EdgeInsets.symmetric(vertical: 2),
+                            decoration: BoxDecoration(
+                              color: Colors.white.withValues(alpha: 0.03),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: const Center(
+                              child: Text('No EPG data',
+                                style: TextStyle(fontSize: 10, color: Colors.white24)),
+                            ),
+                          )
+                        : Stack(
+                            children: [
+                              for (final prog in _programmes!)
+                                _buildProgrammeBlock(prog, dayStart, now, ppm),
+                              // Now indicator line
+                              if (now.year == dayStart.year &&
+                                  now.month == dayStart.month &&
+                                  now.day == dayStart.day)
+                                Positioned(
+                                  left: now.difference(dayStart).inMinutes * ppm,
+                                  top: 0, bottom: 0,
+                                  child: Container(width: 2, color: Colors.red),
+                                ),
+                            ],
+                          ),
               ),
             ),
           ),
         ],
       ),
     );
+  }
+
+  Widget _buildProgrammeBlock(
+      db.EpgProgramme prog, DateTime dayStart, DateTime now, double ppm) {
+    final startMin = prog.start.difference(dayStart).inMinutes.toDouble().clamp(0, 24 * 60);
+    final endMin = prog.stop.difference(dayStart).inMinutes.toDouble().clamp(0, 24 * 60);
+    final width = (endMin - startMin) * ppm;
+    if (width <= 0) return const SizedBox.shrink();
+    final isNow = now.isAfter(prog.start) && now.isBefore(prog.stop);
+
+    return Positioned(
+      left: startMin * ppm,
+      top: 2, bottom: 2,
+      width: width,
+      child: Tooltip(
+        message: '${prog.title}\n${_fmtTime(prog.start)} – ${_fmtTime(prog.stop)}',
+        child: Container(
+          margin: const EdgeInsets.only(right: 1),
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          decoration: BoxDecoration(
+            color: isNow
+                ? const Color(0xFF1A237E).withValues(alpha: 0.9)
+                : const Color(0xFF16213E).withValues(alpha: 0.7),
+            borderRadius: BorderRadius.circular(3),
+            border: isNow ? Border.all(color: Colors.blueAccent, width: 1) : null,
+          ),
+          alignment: Alignment.centerLeft,
+          child: Text(
+            prog.title,
+            style: TextStyle(
+              fontSize: 10,
+              color: isNow ? Colors.white : Colors.white70,
+              fontWeight: isNow ? FontWeight.bold : FontWeight.normal,
+            ),
+            maxLines: 2, overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _fmtTime(DateTime dt) {
+    return '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
   }
 }
 

--- a/lib/features/player/multi_view_screen.dart
+++ b/lib/features/player/multi_view_screen.dart
@@ -86,7 +86,17 @@ class _MultiViewScreenState extends ConsumerState<MultiViewScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.escape): () {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            Navigator.of(context).pop();
+          });
+        },
+      },
+      child: Focus(
+        autofocus: true,
+        child: Scaffold(
       backgroundColor: Colors.black,
       body: Stack(
         children: [
@@ -165,6 +175,8 @@ class _MultiViewScreenState extends ConsumerState<MultiViewScreen> {
           ),
         ],
       ),
+    ),
+    ),
     );
   }
 }

--- a/lib/features/player/player_control_bar.dart
+++ b/lib/features/player/player_control_bar.dart
@@ -1,0 +1,399 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'player_service.dart';
+
+/// TiviMate-style fullscreen player control bar.
+///
+/// Two-row layout on a dark semi-transparent background:
+/// - Top row: volume, resolution badge, transport controls, action icons
+/// - Bottom row: position, seek bar, duration
+class PlayerControlBar extends ConsumerStatefulWidget {
+  /// Callback to show the cast picker dialog.
+  final VoidCallback? onCastTap;
+
+  /// Callback to navigate back / exit fullscreen.
+  final VoidCallback? onBackTap;
+
+  /// Whether the cast session is active.
+  final bool isCasting;
+
+  const PlayerControlBar({
+    super.key,
+    this.onCastTap,
+    this.onBackTap,
+    this.isCasting = false,
+  });
+
+  @override
+  ConsumerState<PlayerControlBar> createState() => _PlayerControlBarState();
+}
+
+class _PlayerControlBarState extends ConsumerState<PlayerControlBar> {
+  bool _visible = true;
+  Timer? _hideTimer;
+
+  // Player state cached from streams
+  double _volume = 100.0;
+  bool _playing = false;
+  Duration _position = Duration.zero;
+  Duration _duration = Duration.zero;
+  int? _videoWidth;
+  int? _videoHeight;
+  bool _isSeeking = false;
+  double _seekValue = 0.0;
+
+  // Stream subscriptions
+  final List<StreamSubscription> _subs = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleHide();
+    _subscribeToPlayer();
+  }
+
+  void _subscribeToPlayer() {
+    final ps = ref.read(playerServiceProvider);
+    final player = ps.player;
+
+    _volume = player.state.volume;
+    _playing = player.state.playing;
+    _position = player.state.position;
+    _duration = player.state.duration;
+    _videoWidth = player.state.width;
+    _videoHeight = player.state.height;
+
+    _subs.add(player.stream.volume.listen((v) {
+      if (mounted) setState(() => _volume = v);
+    }));
+    _subs.add(player.stream.playing.listen((p) {
+      if (mounted) setState(() => _playing = p);
+    }));
+    _subs.add(player.stream.position.listen((p) {
+      if (mounted && !_isSeeking) setState(() => _position = p);
+    }));
+    _subs.add(player.stream.duration.listen((d) {
+      if (mounted) setState(() => _duration = d);
+    }));
+    _subs.add(player.stream.width.listen((w) {
+      if (mounted) setState(() => _videoWidth = w);
+    }));
+    _subs.add(player.stream.height.listen((h) {
+      if (mounted) setState(() => _videoHeight = h);
+    }));
+  }
+
+  // --- Visibility / auto-hide ---
+
+  void _scheduleHide() {
+    _hideTimer?.cancel();
+    _hideTimer = Timer(const Duration(seconds: 5), () {
+      if (mounted) setState(() => _visible = false);
+    });
+  }
+
+  void _onInteraction() {
+    if (!_visible) {
+      setState(() => _visible = true);
+    }
+    _scheduleHide();
+  }
+
+  // --- Helpers ---
+
+  String _formatDuration(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return h > 0 ? '$h:$m:$s' : '00:$m:$s';
+  }
+
+  String _resolutionLabel() {
+    final h = _videoHeight ?? 0;
+    if (h >= 2160) return '4K UHD';
+    if (h >= 1080) return '1080 HD';
+    if (h >= 720) return '720 HD';
+    if (h >= 480) return '480 SD';
+    if (h > 0) return '${h}p';
+    return '—';
+  }
+
+  void _comingSoon(String feature) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('$feature — coming soon'),
+        duration: const Duration(seconds: 1),
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: Colors.grey.shade800,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _hideTimer?.cancel();
+    for (final s in _subs) {
+      s.cancel();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onHover: (_) => _onInteraction(),
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: _onInteraction,
+        child: AnimatedOpacity(
+          opacity: _visible ? 1.0 : 0.0,
+          duration: const Duration(milliseconds: 300),
+          child: IgnorePointer(
+            ignoring: !_visible,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                // ── Top row ──
+                Container(
+                  color: Colors.black.withValues(alpha: 0.7),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  child: Row(
+                    children: [
+                      // Back button
+                      _iconBtn(Icons.arrow_back, onTap: widget.onBackTap),
+                      const SizedBox(width: 4),
+
+                      // Volume icon + slider
+                      Icon(
+                        _volume == 0
+                            ? Icons.volume_off
+                            : _volume < 50
+                                ? Icons.volume_down
+                                : Icons.volume_up,
+                        color: Colors.white,
+                        size: 20,
+                      ),
+                      SizedBox(
+                        width: 100,
+                        child: SliderTheme(
+                          data: SliderTheme.of(context).copyWith(
+                            trackHeight: 3,
+                            thumbShape: const RoundSliderThumbShape(
+                                enabledThumbRadius: 6),
+                            overlayShape: const RoundSliderOverlayShape(
+                                overlayRadius: 12),
+                            activeTrackColor: Colors.white,
+                            inactiveTrackColor: Colors.white24,
+                            thumbColor: Colors.white,
+                          ),
+                          child: Slider(
+                            value: _volume,
+                            min: 0,
+                            max: 100,
+                            onChanged: (v) {
+                              setState(() => _volume = v);
+                              ref.read(playerServiceProvider).setVolume(v);
+                              _scheduleHide();
+                            },
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+
+                      // Resolution badge
+                      _badge(_resolutionLabel()),
+                      const SizedBox(width: 4),
+
+                      // Interlaced badge
+                      _badge('inv',
+                          bgColor: Colors.red.shade700, fontSize: 10),
+                      const SizedBox(width: 4),
+
+                      // Record
+                      _iconBtn(Icons.fiber_manual_record,
+                          color: Colors.red.shade400,
+                          size: 16,
+                          onTap: () => _comingSoon('Recording')),
+                      const SizedBox(width: 4),
+
+                      // Encoding label
+                      _badge('E', fontSize: 10),
+
+                      const Spacer(),
+
+                      // ── Transport controls (center) ──
+                      _iconBtn(Icons.fast_rewind, onTap: () {
+                        final ps = ref.read(playerServiceProvider);
+                        final target = _position - const Duration(seconds: 10);
+                        ps.player.seek(target < Duration.zero
+                            ? Duration.zero
+                            : target);
+                        _scheduleHide();
+                      }),
+                      const SizedBox(width: 12),
+                      _iconBtn(
+                        _playing ? Icons.pause : Icons.play_arrow,
+                        size: 32,
+                        onTap: () {
+                          final ps = ref.read(playerServiceProvider);
+                          _playing ? ps.pause() : ps.resume();
+                          _scheduleHide();
+                        },
+                      ),
+                      const SizedBox(width: 12),
+                      _iconBtn(Icons.fast_forward, onTap: () {
+                        final ps = ref.read(playerServiceProvider);
+                        final target = _position + const Duration(seconds: 10);
+                        ps.player.seek(
+                            target > _duration ? _duration : target);
+                        _scheduleHide();
+                      }),
+
+                      const Spacer(),
+
+                      // ── Right side icons ──
+                      _iconBtn(Icons.camera_alt_outlined,
+                          onTap: () => _comingSoon('Screenshot')),
+                      _iconBtn(Icons.star_border,
+                          onTap: () => _comingSoon('Favorite')),
+                      _iconBtn(Icons.picture_in_picture_alt,
+                          onTap: () => _comingSoon('PiP')),
+                      _iconBtn(
+                        widget.isCasting
+                            ? Icons.cast_connected
+                            : Icons.cast,
+                        color:
+                            widget.isCasting ? Colors.amber : Colors.white,
+                        onTap: widget.onCastTap,
+                      ),
+                      _iconBtn(Icons.info_outline,
+                          onTap: () => _comingSoon('Info')),
+                      _iconBtn(Icons.settings,
+                          onTap: () => _comingSoon('Settings')),
+                      _iconBtn(Icons.list,
+                          onTap: () => _comingSoon('Channel list')),
+                      _iconBtn(Icons.sort,
+                          onTap: () => _comingSoon('Sort/filter')),
+                      _badge('EPG', fontSize: 10),
+                      const SizedBox(width: 6),
+                      _badge('-- fps', fontSize: 10),
+                    ],
+                  ),
+                ),
+
+                // ── Bottom row: seek bar ──
+                Container(
+                  color: Colors.black.withValues(alpha: 0.7),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+                  child: Row(
+                    children: [
+                      Text(
+                        _formatDuration(
+                            _isSeeking
+                                ? Duration(
+                                    milliseconds: _seekValue.round())
+                                : _position),
+                        style: const TextStyle(
+                            color: Colors.white70, fontSize: 12),
+                      ),
+                      Expanded(
+                        child: SliderTheme(
+                          data: SliderTheme.of(context).copyWith(
+                            trackHeight: 3,
+                            thumbShape: const RoundSliderThumbShape(
+                                enabledThumbRadius: 6),
+                            overlayShape: const RoundSliderOverlayShape(
+                                overlayRadius: 10),
+                            activeTrackColor: Colors.blue,
+                            inactiveTrackColor: Colors.white24,
+                            thumbColor: Colors.blue,
+                          ),
+                          child: Slider(
+                            value: _isSeeking
+                                ? _seekValue
+                                : _position.inMilliseconds
+                                    .toDouble()
+                                    .clamp(
+                                        0,
+                                        _duration.inMilliseconds
+                                            .toDouble()
+                                            .clamp(1, double.infinity)),
+                            min: 0,
+                            max: _duration.inMilliseconds
+                                .toDouble()
+                                .clamp(1, double.infinity),
+                            onChangeStart: (v) {
+                              setState(() {
+                                _isSeeking = true;
+                                _seekValue = v;
+                              });
+                            },
+                            onChanged: (v) {
+                              setState(() => _seekValue = v);
+                              _scheduleHide();
+                            },
+                            onChangeEnd: (v) {
+                              ref.read(playerServiceProvider).player.seek(
+                                  Duration(milliseconds: v.round()));
+                              setState(() => _isSeeking = false);
+                            },
+                          ),
+                        ),
+                      ),
+                      Text(
+                        _formatDuration(_duration),
+                        style: const TextStyle(
+                            color: Colors.white70, fontSize: 12),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ── Small helpers ──
+
+  Widget _iconBtn(IconData icon,
+      {VoidCallback? onTap, Color color = Colors.white, double size = 20}) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(16),
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.all(6),
+        child: Icon(icon, color: color, size: size),
+      ),
+    );
+  }
+
+  Widget _badge(String text,
+      {Color bgColor = Colors.transparent, double fontSize = 11}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: bgColor,
+        border: bgColor == Colors.transparent
+            ? Border.all(color: Colors.white38)
+            : null,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: fontSize,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/player/player_service.dart
+++ b/lib/features/player/player_service.dart
@@ -144,6 +144,20 @@ class PlayerService {
     }
   }
 
+  /// Read an mpv property from the underlying native player.
+  /// Returns null if unavailable (e.g. on web or before player init).
+  Future<String?> getMpvProperty(String name) async {
+    final np = player.platform;
+    if (np is native_player.NativePlayer) {
+      try {
+        return await np.getProperty(name);
+      } catch (_) {
+        return null;
+      }
+    }
+    return null;
+  }
+
   void dispose() {
     _tracksSub?.cancel();
     _player?.dispose();

--- a/lib/features/providers/add_provider_dialog.dart
+++ b/lib/features/providers/add_provider_dialog.dart
@@ -155,7 +155,22 @@ class _AddProviderPageState extends ConsumerState<_AddProviderPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.escape): () {
+          final pf = FocusManager.instance.primaryFocus;
+          if (pf?.context?.findAncestorWidgetOfExactType<EditableText>() != null) {
+            pf!.unfocus();
+            return;
+          }
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            Navigator.of(context).pop();
+          });
+        },
+      },
+      child: Focus(
+        autofocus: true,
+        child: Scaffold(
       backgroundColor: const Color(0xFF0A0A0F),
       appBar: AppBar(
         leading: IconButton(
@@ -201,6 +216,8 @@ class _AddProviderPageState extends ConsumerState<_AddProviderPage> {
           ],
         ),
       ),
+    ),
+    ),
     );
   }
 

--- a/lib/features/providers/providers_screen.dart
+++ b/lib/features/providers/providers_screen.dart
@@ -19,13 +19,27 @@ class ProvidersScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final providersAsync = ref.watch(_providersStreamProvider);
 
-    return Scaffold(
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.escape): () {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.canPop()) {
+              context.pop();
+            } else {
+              context.go('/');
+            }
+          });
+        },
+      },
+      child: Focus(
+        autofocus: true,
+        child: Scaffold(
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () {
-            if (Navigator.of(context).canPop()) {
-              Navigator.of(context).pop();
+            if (context.canPop()) {
+              context.pop();
             } else {
               context.go('/');
             }
@@ -63,6 +77,8 @@ class ProvidersScreen extends ConsumerWidget {
           ),
         ),
       ),
+    ),
+    ),
     );
   }
 }

--- a/lib/features/shows/show_detail_screen.dart
+++ b/lib/features/shows/show_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:go_router/go_router.dart';
@@ -111,7 +112,21 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
       showDetailProvider(ShowDetailParams(widget.traktId, type: type)),
     );
 
-    return Scaffold(
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.escape): () {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.canPop()) {
+              context.pop();
+            } else {
+              context.go('/shows');
+            }
+          });
+        },
+      },
+      child: Focus(
+        autofocus: true,
+        child: Scaffold(
       backgroundColor: _dominantColor != null
           ? Color.lerp(const Color(0xFF0A0A1A), _dominantColor!, 0.15)!
           : const Color(0xFF0A0A1A),
@@ -129,6 +144,8 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
           return _buildDetail(detail);
         },
       ),
+    ),
+    ),
     );
   }
 

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -16,5 +16,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Changes

### ESC Key Fixes
- Fix ESC key state assertion error on ALL screens (defer navigation with `addPostFrameCallback`)
- Add ESC handling to guide and multi-view screens
- Fix EPG sources ESC (use `FocusScope` instead of `Focus`)
- Fix search field keyboard (ESC doesn't steal focus from TextFields)

### Guide EPG Data
- Wire guide screen to actually load and display EPG programme data
- Load EPG mappings at screen init, resolve channel→EPG IDs
- Query programmes for the day and render as timeline blocks with now indicator

### Player Controls
- Add TiviMate-style fullscreen player control bar (volume slider, resolution badge, seek bar, cast, screenshot, favorite, PiP, info, settings, FPS counter)
- Auto-show/hide on mouse movement (5s timeout)

### Debug Info Overlay
- Add VLC-style debug overlay toggled with D key
- Shows codec, resolution, FPS, bitrate, buffer health, container format
- Also accessible from player control bar info button

### Bug Fixes
- Fix rename channel cancel crash (mounted checks, controller dispose)
- Fix EPG sources screen errors (try/catch, loading/error states)
- Show EPG data on favorite channels (refresh now-playing on favorites switch)
- Fix recording snackbar duration (5s auto-dismiss)
- Widen Play Network Stream dialog (500px)
- Remove sidebar search on desktop (keep top search bar only)
- Enhance top search with channel name + programme title OR keyword matching
- Add macOS read-only file entitlement for file picker