### PR TITLE
🐛 Fix Play URL dialog keyboard overlap and ESC/BACK dismiss

### DIFF
--- a/lib/features/channels/channels_screen.dart
+++ b/lib/features/channels/channels_screen.dart
@@ -2000,27 +2000,37 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
     final controller = TextEditingController();
     final url = await showDialog<String>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Play Network Stream'),
-        content: SizedBox(
-          width: 500,
-          child: TextField(
-            controller: controller,
-            autofocus: true,
-            decoration: const InputDecoration(
-              hintText: 'http:// or rtsp:// stream URL',
-              isDense: true,
+      builder: (ctx) => CallbackShortcuts(
+        bindings: {
+          const SingleActivator(LogicalKeyboardKey.escape): () => Navigator.pop(ctx),
+          const SingleActivator(LogicalKeyboardKey.goBack): () => Navigator.pop(ctx),
+        },
+        child: Focus(
+          autofocus: !Platform.isAndroid,
+          child: AlertDialog(
+            title: const Text('Play Network Stream'),
+            content: SizedBox(
+              width: 500,
+              child: TextField(
+                controller: controller,
+                autofocus: true,
+                keyboardType: Platform.isAndroid ? TextInputType.none : TextInputType.url,
+                decoration: const InputDecoration(
+                  hintText: 'http:// or rtsp:// stream URL',
+                  isDense: true,
+                ),
+                onSubmitted: (v) => Navigator.pop(ctx, v.trim()),
+              ),
             ),
-            onSubmitted: (v) => Navigator.pop(ctx, v.trim()),
+            actions: [
+              TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+              FilledButton(
+                onPressed: () => Navigator.pop(ctx, controller.text.trim()),
+                child: const Text('Play'),
+              ),
+            ],
           ),
         ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, controller.text.trim()),
-            child: const Text('Play'),
-          ),
-        ],
       ),
     );
     if (url != null && url.isNotEmpty && mounted) {


### PR DESCRIPTION
- Suppress Android TV soft keyboard with `TextInputType.none` (no overlap)
- Add `CallbackShortcuts` for ESC and BACK key to dismiss dialog
- Dialog now opens cleanly with Cancel/Play buttons, dismisses with remote BACK