### PR TITLE
🐛 Fix Play URL dialog: restore keyboard, fix BACK dismiss

### DIFF
--- a/lib/features/channels/channels_screen.dart
+++ b/lib/features/channels/channels_screen.dart
@@ -2000,38 +2000,40 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
     final controller = TextEditingController();
     final url = await showDialog<String>(
       context: context,
-      builder: (ctx) => CallbackShortcuts(
-        bindings: {
-          const SingleActivator(LogicalKeyboardKey.escape): () => Navigator.pop(ctx),
-          const SingleActivator(LogicalKeyboardKey.goBack): () => Navigator.pop(ctx),
-        },
-        child: Focus(
-          autofocus: !Platform.isAndroid,
-          child: AlertDialog(
-            title: const Text('Play Network Stream'),
-            content: SizedBox(
-              width: 500,
-              child: TextField(
-                controller: controller,
-                autofocus: true,
-                keyboardType: Platform.isAndroid ? TextInputType.none : TextInputType.url,
-                decoration: const InputDecoration(
-                  hintText: 'http:// or rtsp:// stream URL',
-                  isDense: true,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) {
+            final bottomInset = MediaQuery.of(ctx).viewInsets.bottom;
+            return AnimatedPadding(
+              duration: const Duration(milliseconds: 200),
+              padding: EdgeInsets.only(bottom: bottomInset),
+              child: AlertDialog(
+                title: const Text('Play Network Stream'),
+                content: SizedBox(
+                  width: 500,
+                  child: TextField(
+                    controller: controller,
+                    autofocus: true,
+                    keyboardType: TextInputType.url,
+                    decoration: const InputDecoration(
+                      hintText: 'http:// or rtsp:// stream URL',
+                      isDense: true,
+                    ),
+                    onSubmitted: (v) => Navigator.pop(ctx, v.trim()),
+                  ),
                 ),
-                onSubmitted: (v) => Navigator.pop(ctx, v.trim()),
+                actions: [
+                  TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+                  FilledButton(
+                    onPressed: () => Navigator.pop(ctx, controller.text.trim()),
+                    child: const Text('Play'),
+                  ),
+                ],
               ),
-            ),
-            actions: [
-              TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
-              FilledButton(
-                onPressed: () => Navigator.pop(ctx, controller.text.trim()),
-                child: const Text('Play'),
-              ),
-            ],
-          ),
-        ),
-      ),
+            );
+          },
+        );
+      },
     );
     if (url != null && url.isNotEmpty && mounted) {
       final playerService = ref.read(playerServiceProvider);


### PR DESCRIPTION
Fixes the Play Network Stream dialog:
- Restores soft keyboard so URLs can be typed on Android TV
- Uses `AnimatedPadding` with `MediaQuery.viewInsets` for keyboard inset
- Removes broken `CallbackShortcuts` (TextField stole focus from it)
- BACK key flow: 1st press dismisses keyboard → 2nd press dismisses dialog