### PR TITLE
✨ Auto-failover, vanity names, EPG call-sign matching, adaptive buffering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+flutter_02.png

--- a/lib/core/weather_service.dart
+++ b/lib/core/weather_service.dart
@@ -1,6 +1,10 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const weatherZipKey = 'weather_zipcode';
+const weatherCityKey = 'weather_city_name';
 
 class WeatherData {
   final String city;
@@ -31,19 +35,71 @@ String _weatherCodeToIcon(int code) {
   return '🌡️';
 }
 
+/// Geocode a US zip code via Open-Meteo's geocoding API.
+/// Returns {lat, lon, city} or null on failure.
+Future<Map<String, dynamic>?> geocodeZipcode(String zip) async {
+  try {
+    final resp = await http.get(Uri.parse(
+      'https://geocoding-api.open-meteo.com/v1/search?name=$zip&count=1&language=en&format=json',
+    ));
+    if (resp.statusCode != 200) return null;
+    final data = jsonDecode(resp.body);
+    final results = data['results'] as List?;
+    if (results == null || results.isEmpty) return null;
+    final r = results[0];
+    return {
+      'lat': r['latitude'],
+      'lon': r['longitude'],
+      'city': r['name'] ?? zip,
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
 class WeatherNotifier extends StateNotifier<WeatherData?> {
   WeatherNotifier() : super(null) {
     _fetch();
   }
 
+  /// Force a refresh (called after user changes location in settings).
+  void refresh() => _fetch();
+
   Future<void> _fetch() async {
     try {
-      final locResp = await http.get(Uri.parse('https://ipapi.co/json/'));
-      if (locResp.statusCode != 200) return;
-      final loc = jsonDecode(locResp.body);
-      final lat = loc['latitude'];
-      final lon = loc['longitude'];
-      final city = loc['city'] ?? '';
+      double? lat;
+      double? lon;
+      String city = '';
+
+      // Check if user has set a zipcode in preferences
+      final prefs = await SharedPreferences.getInstance();
+      final savedZip = prefs.getString(weatherZipKey);
+
+      if (savedZip != null && savedZip.isNotEmpty) {
+        final geo = await geocodeZipcode(savedZip);
+        if (geo != null) {
+          lat = (geo['lat'] as num).toDouble();
+          lon = (geo['lon'] as num).toDouble();
+          city = prefs.getString(weatherCityKey) ?? geo['city'] as String;
+        }
+      }
+
+      // Fallback to IP-based geolocation
+      if (lat == null || lon == null) {
+        final locResp = await http.get(Uri.parse('https://ipapi.co/json/'));
+        if (locResp.statusCode != 200) return;
+        final loc = jsonDecode(locResp.body);
+        lat = (loc['latitude'] as num).toDouble();
+        lon = (loc['longitude'] as num).toDouble();
+        city = loc['city'] ?? '';
+
+        // Prefill the saved zipcode/city for settings UI
+        final detectedZip = loc['postal'] ?? '';
+        if (detectedZip.isNotEmpty && (savedZip == null || savedZip.isEmpty)) {
+          await prefs.setString(weatherZipKey, detectedZip);
+          await prefs.setString(weatherCityKey, city);
+        }
+      }
 
       final wxResp = await http.get(Uri.parse(
         'https://api.open-meteo.com/v1/forecast'

--- a/lib/data/services/stream_alternatives_service.dart
+++ b/lib/data/services/stream_alternatives_service.dart
@@ -1,0 +1,287 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../datasources/local/database.dart' as db;
+import '../models/channel.dart' hide Provider;
+import 'stream_health_tracker.dart';
+import '../../features/providers/provider_manager.dart';
+
+/// Maintains a real-time index of alternative streams for each channel.
+///
+/// Channels are grouped for failover using this priority chain:
+///   1. **Same vanity name** — user explicitly confirmed channels are interchangeable
+///   2. **Same tvgId** across providers — provider-assigned content ID
+///   3. **Same EPG + same call sign** — avoids false matches across local affiliates
+///      (e.g., ABC WABC New York ≠ ABC WLS Chicago even though both map to "ABC" EPG)
+///   4. **Normalized name match** (strip HD/SD/region tags)
+///   5. **Fuzzy keyword match** (lowest confidence)
+///
+/// NOTE: EPG assignment alone is NOT sufficient for grouping. Local channels
+/// (ABC, CBS, NBC, FOX) share network EPG but air different local programming.
+/// Only channels with matching call signs or user-confirmed vanity names are
+/// considered truly interchangeable.
+class StreamAlternativesService {
+  final db.AppDatabase _db;
+  final StreamHealthTracker _health;
+
+  /// Vanity name → list of channels (user-confirmed grouping).
+  Map<String, List<Channel>> _vanityIndex = {};
+
+  /// EPG channel ID → list of channels (from all providers).
+  Map<String, List<Channel>> _epgIndex = {};
+
+  /// tvgId → list of channels.
+  Map<String, List<Channel>> _tvgIdIndex = {};
+
+  /// Normalized name → list of channels.
+  Map<String, List<Channel>> _nameIndex = {};
+
+  /// All channels cached for fuzzy fallback.
+  List<Channel> _allChannels = [];
+
+  StreamAlternativesService(this._db, this._health);
+
+  /// Rebuild the index. Call on init, after EPG refresh, or provider changes.
+  Future<void> rebuild() async {
+    _vanityIndex.clear();
+    _epgIndex.clear();
+    _tvgIdIndex.clear();
+    _nameIndex.clear();
+
+    final channels = await _db.getAllChannels();
+    final mappings = await _db.getAllMappings();
+    _allChannels = channels.map(_dbToChannel).toList();
+
+    // Load vanity names from SharedPreferences
+    Map<String, String> vanityNames = {};
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final vanityJson = prefs.getString('channel_vanity_names');
+      if (vanityJson != null) {
+        final decoded = jsonDecode(vanityJson) as Map<String, dynamic>;
+        vanityNames = decoded.map((k, v) => MapEntry(k, v as String));
+      }
+    } catch (_) {}
+
+    // Build channelId → epgChannelId lookup from mappings
+    final channelToEpg = <String, String>{};
+    for (final m in mappings) {
+      channelToEpg[m.channelId] = m.epgChannelId;
+    }
+
+    for (final ch in _allChannels) {
+      if (ch.streamUrl.isEmpty) continue;
+
+      // 1. Vanity name index (user-confirmed grouping — highest trust)
+      final vanity = vanityNames[ch.id];
+      if (vanity != null && vanity.isNotEmpty) {
+        final key = vanity.toLowerCase().trim();
+        _vanityIndex.putIfAbsent(key, () => []).add(ch);
+      }
+
+      // 2. EPG-based index
+      final epgId = channelToEpg[ch.id] ?? ch.epgChannelId;
+      if (epgId != null && epgId.isNotEmpty) {
+        _epgIndex.putIfAbsent(epgId, () => []).add(ch);
+      }
+
+      // 3. tvgId-based index
+      if (ch.tvgId != null && ch.tvgId!.isNotEmpty) {
+        _tvgIdIndex.putIfAbsent(ch.tvgId!, () => []).add(ch);
+      }
+
+      // 4. Normalized name index
+      final normName = _normalizeName(ch.name);
+      if (normName.isNotEmpty) {
+        _nameIndex.putIfAbsent(normName, () => []).add(ch);
+      }
+    }
+  }
+
+  /// Get ranked alternative stream URLs for a channel.
+  ///
+  /// Returns URLs sorted by health score (best first), excluding
+  /// [excludeUrl] (the currently-playing stream).
+  List<String> getAlternatives({
+    required String channelId,
+    String? epgChannelId,
+    String? tvgId,
+    String? channelName,
+    String? vanityName,
+    required String excludeUrl,
+  }) {
+    final seen = <String>{excludeUrl};
+    final results = <String>[];
+
+    void addCandidates(List<Channel>? channels) {
+      if (channels == null) return;
+      for (final ch in channels) {
+        if (ch.id != channelId &&
+            ch.streamUrl.isNotEmpty &&
+            seen.add(ch.streamUrl)) {
+          results.add(ch.streamUrl);
+        }
+      }
+    }
+
+    // Priority 1: Same vanity name (user-confirmed interchangeable)
+    if (vanityName != null && vanityName.isNotEmpty) {
+      final key = vanityName.toLowerCase().trim();
+      addCandidates(_vanityIndex[key]);
+    }
+
+    // Priority 2: Same tvgId across providers
+    if (tvgId != null && tvgId.isNotEmpty) {
+      addCandidates(_tvgIdIndex[tvgId]);
+    }
+
+    // Priority 3: Same EPG + same call sign
+    // Only match if channels share a call sign (e.g., both WABC)
+    // to avoid false matches across local affiliates
+    if (epgChannelId != null && epgChannelId.isNotEmpty) {
+      final callSign = _extractCallSign(channelName ?? '');
+      final epgGroup = _epgIndex[epgChannelId];
+      if (epgGroup != null && callSign != null) {
+        final sameCallSign = epgGroup.where((ch) {
+          final otherCall = _extractCallSign(ch.name);
+          return otherCall != null && otherCall == callSign;
+        }).toList();
+        addCandidates(sameCallSign);
+      } else if (callSign == null) {
+        // Non-local channel (ESPN, CNN, etc.) — EPG match is safe
+        addCandidates(epgGroup);
+      }
+    }
+
+    // Priority 4: Normalized name match
+    if (channelName != null && channelName.isNotEmpty) {
+      final normName = _normalizeName(channelName);
+      addCandidates(_nameIndex[normName]);
+    }
+
+    // Priority 5: Fuzzy keyword match
+    if (results.isEmpty && channelName != null) {
+      final words = _normalizeName(channelName)
+          .split(RegExp(r'\s+'))
+          .where((w) => w.length > 2)
+          .toList();
+      if (words.isNotEmpty) {
+        for (final ch in _allChannels) {
+          if (ch.id != channelId &&
+              ch.streamUrl.isNotEmpty &&
+              seen.add(ch.streamUrl)) {
+            final lower = ch.name.toLowerCase();
+            if (words.every((w) => lower.contains(w))) {
+              results.add(ch.streamUrl);
+            }
+          }
+        }
+      }
+    }
+
+    // Rank by health score (best first)
+    if (results.length > 1) {
+      final ranked = _health.rankUrls(results);
+      return ranked.map((e) => e.key).toList();
+    }
+
+    return results;
+  }
+
+  /// How many alternative streams exist for a channel.
+  int alternativeCount({
+    String? epgChannelId,
+    String? tvgId,
+    String? channelName,
+    String? vanityName,
+  }) {
+    if (vanityName != null && vanityName.isNotEmpty) {
+      final key = vanityName.toLowerCase().trim();
+      final count = (_vanityIndex[key]?.length ?? 1) - 1;
+      if (count > 0) return count;
+    }
+    int count = 0;
+    if (tvgId != null && _tvgIdIndex.containsKey(tvgId)) {
+      count = _tvgIdIndex[tvgId]!.length - 1;
+    }
+    if (count > 0) return count;
+    if (epgChannelId != null && _epgIndex.containsKey(epgChannelId)) {
+      count = _epgIndex[epgChannelId]!.length - 1;
+    }
+    if (count > 0) return count;
+    if (channelName != null) {
+      final norm = _normalizeName(channelName);
+      if (_nameIndex.containsKey(norm)) {
+        count = _nameIndex[norm]!.length - 1;
+      }
+    }
+    return count.clamp(0, 999);
+  }
+
+  /// Extract a US broadcast call sign from a channel name.
+  /// Returns null for cable/satellite channels (ESPN, CNN, etc.).
+  /// Examples: "ABC 7 (WABC) NEW YORK" → "WABC", "CBS 2 WCBS" → "WCBS"
+  static String? _extractCallSign(String name) {
+    // Match parenthesized call signs: (WABC), (WCBS), etc.
+    final parenMatch = RegExp(r'\(([WKOC][A-Z]{2,4})\)', caseSensitive: false)
+        .firstMatch(name);
+    if (parenMatch != null) return parenMatch.group(1)!.toUpperCase();
+
+    // Match standalone call signs: WABC, WCBS, KABC, etc.
+    // US broadcast call signs start with W (east) or K (west), 3-4 letters
+    final standaloneMatch = RegExp(r'\b([WK][A-Z]{2,4})\b').firstMatch(name.toUpperCase());
+    if (standaloneMatch != null) return standaloneMatch.group(1)!;
+
+    return null;
+  }
+
+  static String _normalizeName(String name) {
+    return name
+        .toLowerCase()
+        .replaceAll(
+            RegExp(r'\b(hd|fhd|shd|sd|4k|uhd|hevc|h\.?265)\b',
+                caseSensitive: false),
+            '')
+        .replaceAll(
+            RegExp(r'\b(us|uk|ca|mx|au|nz)-?\b', caseSensitive: false), '')
+        .replaceAll(RegExp(r'[^\w\s]'), '')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+  }
+
+  Channel _dbToChannel(db.Channel c) => Channel(
+        id: c.id,
+        providerId: c.providerId,
+        name: c.name,
+        tvgId: c.tvgId,
+        tvgName: c.tvgName,
+        tvgLogo: c.tvgLogo,
+        groupTitle: c.groupTitle,
+        streamUrl: c.streamUrl,
+        streamType: c.streamType == 'vod'
+            ? StreamType.vod
+            : c.streamType == 'series'
+                ? StreamType.series
+                : StreamType.live,
+      );
+}
+
+// ---------------------------------------------------------------------------
+// Riverpod providers
+// ---------------------------------------------------------------------------
+
+final streamHealthTrackerProvider = Provider<StreamHealthTracker>((ref) {
+  final tracker = StreamHealthTracker();
+  tracker.load();
+  return tracker;
+});
+
+final streamAlternativesProvider = Provider<StreamAlternativesService>((ref) {
+  final db = ref.read(databaseProvider);
+  final health = ref.read(streamHealthTrackerProvider);
+  final service = StreamAlternativesService(db, health);
+  service.rebuild(); // initial build
+  return service;
+});

--- a/lib/data/services/stream_health_tracker.dart
+++ b/lib/data/services/stream_health_tracker.dart
@@ -1,0 +1,161 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tracks per-stream health metrics for ranking failover alternatives.
+///
+/// Metrics: stall count, average buffer level, time-to-first-frame.
+/// Persisted to SharedPreferences, decayed over time so recent data
+/// weighs more than old data.
+class StreamHealthTracker {
+  static const _prefsKey = 'stream_health_scores';
+  static const _maxEntries = 300;
+  static const _decayDays = 7;
+
+  Map<String, _StreamMetrics> _metrics = {};
+  bool _loaded = false;
+
+  /// Load persisted metrics from disk.
+  Future<void> load() async {
+    if (_loaded) return;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final json = prefs.getString(_prefsKey);
+      if (json != null) {
+        final map = jsonDecode(json) as Map<String, dynamic>;
+        _metrics = map.map((k, v) => MapEntry(k, _StreamMetrics.fromJson(v)));
+      }
+    } catch (_) {}
+    _loaded = true;
+  }
+
+  /// Record a buffering stall on a stream.
+  void recordStall(String url) {
+    final m = _getOrCreate(url);
+    m.stallCount++;
+    m.lastUpdated = DateTime.now();
+    _scheduleSave();
+  }
+
+  /// Record a buffer level sample (seconds of cache).
+  void recordBufferSample(String url, double seconds) {
+    final m = _getOrCreate(url);
+    m.bufferSamples++;
+    m.bufferSum += seconds;
+    m.lastUpdated = DateTime.now();
+    // Don't save on every sample — too frequent
+  }
+
+  /// Record time-to-first-frame in milliseconds.
+  void recordTTFF(String url, int ms) {
+    final m = _getOrCreate(url);
+    m.ttffMs = ms;
+    m.lastUpdated = DateTime.now();
+    _scheduleSave();
+  }
+
+  /// Get a health score for a stream URL (0.0 = terrible, 1.0 = excellent).
+  /// Unknown streams return 0.5 (neutral).
+  double getScore(String url) {
+    final key = _urlKey(url);
+    final m = _metrics[key];
+    if (m == null) return 0.5;
+
+    // Apply time decay — halve weight after _decayDays
+    final age = DateTime.now().difference(m.lastUpdated).inHours;
+    final decay = 1.0 / (1.0 + age / (_decayDays * 24));
+
+    // Score components (0-1 each)
+    final stallScore = 1.0 / (1.0 + m.stallCount * 0.3);
+    final bufferScore = m.bufferSamples > 0
+        ? ((m.bufferSum / m.bufferSamples) / 10.0).clamp(0.0, 1.0)
+        : 0.5;
+    final ttffScore = m.ttffMs > 0
+        ? (1.0 - (m.ttffMs / 10000.0)).clamp(0.0, 1.0)
+        : 0.5;
+
+    // Weighted average with decay
+    return ((stallScore * 0.5 + bufferScore * 0.3 + ttffScore * 0.2) * decay)
+        .clamp(0.0, 1.0);
+  }
+
+  /// Get scores for multiple URLs, sorted best-first.
+  List<MapEntry<String, double>> rankUrls(List<String> urls) {
+    final scored = urls.map((u) => MapEntry(u, getScore(u))).toList();
+    scored.sort((a, b) => b.value.compareTo(a.value));
+    return scored;
+  }
+
+  _StreamMetrics _getOrCreate(String url) {
+    final key = _urlKey(url);
+    return _metrics.putIfAbsent(key, () => _StreamMetrics(url: url));
+  }
+
+  String _urlKey(String url) => url.hashCode.toRadixString(36);
+
+  bool _saveScheduled = false;
+
+  void _scheduleSave() {
+    if (_saveScheduled) return;
+    _saveScheduled = true;
+    Future.delayed(const Duration(seconds: 5), () async {
+      _saveScheduled = false;
+      await _save();
+    });
+  }
+
+  /// Force a save (call on app shutdown).
+  Future<void> save() => _save();
+
+  Future<void> _save() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      // Prune old entries
+      if (_metrics.length > _maxEntries) {
+        final entries = _metrics.entries.toList()
+          ..sort((a, b) => a.value.lastUpdated.compareTo(b.value.lastUpdated));
+        for (var i = 0; i < entries.length - _maxEntries; i++) {
+          _metrics.remove(entries[i].key);
+        }
+      }
+      final json = _metrics.map((k, v) => MapEntry(k, v.toJson()));
+      await prefs.setString(_prefsKey, jsonEncode(json));
+    } catch (_) {}
+  }
+}
+
+class _StreamMetrics {
+  final String url;
+  int stallCount;
+  double bufferSum;
+  int bufferSamples;
+  int ttffMs;
+  DateTime lastUpdated;
+
+  _StreamMetrics({
+    required this.url,
+    this.stallCount = 0,
+    this.bufferSum = 0,
+    this.bufferSamples = 0,
+    this.ttffMs = 0,
+    DateTime? lastUpdated,
+  }) : lastUpdated = lastUpdated ?? DateTime.now();
+
+  Map<String, dynamic> toJson() => {
+        'url': url,
+        'stalls': stallCount,
+        'bufSum': bufferSum,
+        'bufN': bufferSamples,
+        'ttff': ttffMs,
+        'ts': lastUpdated.millisecondsSinceEpoch,
+      };
+
+  factory _StreamMetrics.fromJson(Map<String, dynamic> j) => _StreamMetrics(
+        url: j['url'] ?? '',
+        stallCount: j['stalls'] ?? 0,
+        bufferSum: (j['bufSum'] ?? 0).toDouble(),
+        bufferSamples: j['bufN'] ?? 0,
+        ttffMs: j['ttff'] ?? 0,
+        lastUpdated: DateTime.fromMillisecondsSinceEpoch(j['ts'] ?? 0),
+      );
+}

--- a/lib/features/player/adaptive_buffer.dart
+++ b/lib/features/player/adaptive_buffer.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:media_kit/src/player/native/player/real.dart' as native_player;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'player_service.dart';
+
+/// Adaptive per-stream buffer manager.
+///
+/// Monitors `demuxer-cache-duration` to gauge stream health and adjusts
+/// mpv buffer properties bidirectionally across three tiers:
+///   - **fast**:       Small buffer, fast channel switching (good streams)
+///   - **normal**:     Default balanced buffer
+///   - **aggressive**: Large buffer for flaky streams
+///
+/// Tier is persisted per stream URL so returning to a channel uses the
+/// learned profile immediately. Tiers float both ways based on a rolling
+/// window of buffer health observations.
+class AdaptiveBufferManager {
+  static const _prefsKey = 'adaptive_buffer_profiles';
+
+  // Buffer tier definitions (mpv properties)
+  // All tiers share high maximums, but differ in pause behavior:
+  //   fast:       Never pause for buffer — instant channel switching
+  //   normal:     Brief pause if buffer critically empty
+  //   aggressive: Pause up to 3s to build buffer, more readahead
+  static const _tierConfig = <String, Map<String, String>>{
+    'fast': {
+      'cache': 'yes',
+      'cache-secs': '180',
+      'cache-pause-initial': 'no',
+      'cache-pause-wait': '1',
+      'demuxer-max-bytes': '800M',
+      'demuxer-max-back-bytes': '200M',
+      'demuxer-readahead-secs': '60',
+    },
+    'normal': {
+      'cache': 'yes',
+      'cache-secs': '180',
+      'cache-pause-initial': 'no',
+      'cache-pause-wait': '2',
+      'demuxer-max-bytes': '800M',
+      'demuxer-max-back-bytes': '200M',
+      'demuxer-readahead-secs': '120',
+    },
+    'aggressive': {
+      'cache': 'yes',
+      'cache-secs': '180',
+      'cache-pause-initial': 'yes',
+      'cache-pause-wait': '3',
+      'demuxer-max-bytes': '800M',
+      'demuxer-max-back-bytes': '200M',
+      'demuxer-readahead-secs': '180',
+    },
+  };
+
+  static const _tierOrder = ['fast', 'normal', 'aggressive'];
+
+  /// Seconds of stable buffer before downgrading tier.
+  static const _downgradeAfterStableSecs = 60;
+
+  /// Number of low-buffer observations before upgrading tier.
+  static const _upgradeAfterStallCount = 3;
+
+  /// Cache duration below which we consider the buffer stressed.
+  static const _lowBufferThreshold = 1.5;
+
+  /// Cache duration above which we consider the buffer healthy.
+  static const _healthyBufferThreshold = 4.0;
+
+  Timer? _monitorTimer;
+  String _currentTier = 'normal';
+  String? _currentUrl;
+
+  // Health tracking — reset per stream
+  int _stableSeconds = 0;
+  int _stallCount = 0;
+
+  /// Current tier for display/debugging.
+  String get currentTier => _currentTier;
+
+  /// Apply buffer settings for a stream URL and begin monitoring.
+  Future<void> applyForStream(String url, PlayerService ps) async {
+    _monitorTimer?.cancel();
+    _currentUrl = url;
+    _stableSeconds = 0;
+    _stallCount = 0;
+
+    // Load saved tier or default to 'normal'
+    _currentTier = await _loadTier(url);
+    await _applyTier(_currentTier, ps);
+    _startMonitoring(url, ps);
+  }
+
+  /// Stop monitoring (call on stream stop or dispose).
+  void stop() {
+    _monitorTimer?.cancel();
+    _currentUrl = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Monitoring loop
+  // ---------------------------------------------------------------------------
+
+  void _startMonitoring(String url, PlayerService ps) {
+    _monitorTimer = Timer.periodic(const Duration(seconds: 2), (_) async {
+      if (_currentUrl != url) return; // stream changed
+
+      final raw = await ps.getMpvProperty('demuxer-cache-duration');
+      final cacheSecs = double.tryParse(raw ?? '');
+      if (cacheSecs == null) return; // not available yet
+
+      if (cacheSecs < _lowBufferThreshold) {
+        // Buffer stressed
+        _stallCount++;
+        _stableSeconds = 0;
+
+        if (_stallCount >= _upgradeAfterStallCount) {
+          final upgraded = _upgradeTier();
+          if (upgraded) {
+            await _applyTier(_currentTier, ps);
+            await _saveTier(url, _currentTier);
+            _stallCount = 0;
+          }
+        }
+      } else if (cacheSecs > _healthyBufferThreshold) {
+        // Buffer healthy
+        _stableSeconds += 2;
+        _stallCount = (_stallCount > 0) ? _stallCount - 1 : 0;
+
+        if (_stableSeconds >= _downgradeAfterStableSecs) {
+          final downgraded = _downgradeTier();
+          if (downgraded) {
+            await _applyTier(_currentTier, ps);
+            await _saveTier(url, _currentTier);
+          }
+          _stableSeconds = 0;
+        }
+      }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tier management
+  // ---------------------------------------------------------------------------
+
+  /// Move to a higher buffer tier. Returns true if tier changed.
+  bool _upgradeTier() {
+    final idx = _tierOrder.indexOf(_currentTier);
+    if (idx < _tierOrder.length - 1) {
+      _currentTier = _tierOrder[idx + 1];
+      return true;
+    }
+    return false;
+  }
+
+  /// Move to a lower buffer tier. Returns true if tier changed.
+  bool _downgradeTier() {
+    final idx = _tierOrder.indexOf(_currentTier);
+    if (idx > 0) {
+      _currentTier = _tierOrder[idx - 1];
+      return true;
+    }
+    return false;
+  }
+
+  Future<void> _applyTier(String tier, PlayerService ps) async {
+    final config = _tierConfig[tier] ?? _tierConfig['normal']!;
+    for (final entry in config.entries) {
+      await _setMpvProperty(ps, entry.key, entry.value);
+    }
+  }
+
+  Future<void> _setMpvProperty(PlayerService ps, String key, String value) async {
+    try {
+      final np = ps.player.platform;
+      if (np is native_player.NativePlayer) {
+        await np.setProperty(key, value);
+      }
+    } catch (_) {
+      // Property might not be settable mid-stream — that's OK
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence (SharedPreferences)
+  // ---------------------------------------------------------------------------
+
+  /// Use a short hash of the URL as key to keep storage compact.
+  String _urlKey(String url) => url.hashCode.toRadixString(36);
+
+  Future<String> _loadTier(String url) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final json = prefs.getString(_prefsKey);
+      if (json != null) {
+        final map = jsonDecode(json) as Map<String, dynamic>;
+        final tier = map[_urlKey(url)] as String?;
+        if (tier != null && _tierConfig.containsKey(tier)) return tier;
+      }
+    } catch (_) {}
+    return 'normal';
+  }
+
+  Future<void> _saveTier(String url, String tier) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final json = prefs.getString(_prefsKey);
+      final map = json != null
+          ? (jsonDecode(json) as Map<String, dynamic>)
+          : <String, dynamic>{};
+      map[_urlKey(url)] = tier;
+      // Keep only last 200 entries to avoid unbounded growth
+      if (map.length > 200) {
+        final keys = map.keys.toList();
+        for (var i = 0; i < keys.length - 200; i++) {
+          map.remove(keys[i]);
+        }
+      }
+      await prefs.setString(_prefsKey, jsonEncode(map));
+    } catch (_) {}
+  }
+}

--- a/lib/features/player/player_service.dart
+++ b/lib/features/player/player_service.dart
@@ -6,16 +6,45 @@ import 'package:media_kit/media_kit.dart';
 import 'package:media_kit/src/player/native/player/real.dart' as native_player;
 import 'package:media_kit_video/media_kit_video.dart';
 
+import 'adaptive_buffer.dart';
+import '../../data/services/stream_alternatives_service.dart';
+import '../../data/services/stream_health_tracker.dart';
+
 /// Manages video playback with stream failover support.
 class PlayerService {
   Player? _player;
   VideoController? _videoController;
+  final AdaptiveBufferManager _bufferManager = AdaptiveBufferManager();
   bool _isBuffering = false;
   DateTime? _bufferStartTime;
   StreamSubscription<Tracks>? _tracksSub;
 
+  // Buffer health tracking (persists across info dialog opens)
+  final List<bool> bufferHistory = List.filled(60, false, growable: true);
+  int bufferEventCount = 0;
+  int bufferingSeconds = 0;
+  bool _trackingBuffering = false;
+  Timer? _bufferTrackTimer;
+  StreamSubscription<bool>? _bufferTrackSub;
+
   /// Buffer stall threshold before triggering failover.
   static const bufferStallThreshold = Duration(seconds: 3);
+
+  // Auto-failover state
+  String? _currentUrl;
+  String? _currentChannelId;
+  String? _currentEpgChannelId;
+  String? _currentTvgId;
+  String? _currentChannelName;
+  String? _currentVanityName;
+  StreamAlternativesService? _alternatives;
+  StreamHealthTracker? _healthTracker;
+  Timer? _failoverCheckTimer;
+  int _consecutiveLowBuffer = 0;
+
+  /// Callback invoked when auto-failover switches streams.
+  /// Provides the provider name or URL fragment for UI toast.
+  void Function(String message)? onFailover;
 
   bool _playerReady = false;
   final _playerReadyCompleter = Completer<void>();
@@ -52,10 +81,6 @@ class PlayerService {
         await np.setProperty('hwdec', 'mediacodec-copy');
         await np.setProperty('vo', 'gpu');
         await np.setProperty('framedrop', 'vo');
-        await np.setProperty('cache', 'yes');
-        await np.setProperty('cache-secs', '10');
-        await np.setProperty('demuxer-max-bytes', '50M');
-        await np.setProperty('demuxer-max-back-bytes', '5M');
       }
     }
     await p.setVolume(100);
@@ -77,14 +102,42 @@ class PlayerService {
     return _videoController!;
   }
 
-  /// Start playing a stream URL.
-  Future<void> play(String url) async {
+  /// Inject services for auto-failover (call once at startup).
+  void configureFailover(StreamAlternativesService alternatives, StreamHealthTracker health) {
+    _alternatives = alternatives;
+    _healthTracker = health;
+  }
+
+  /// Start playing a stream URL with optional channel metadata for failover.
+  Future<void> play(String url, {
+    String? channelId,
+    String? epgChannelId,
+    String? tvgId,
+    String? channelName,
+    String? vanityName,
+  }) async {
     _isBuffering = false;
     _bufferStartTime = null;
+    _consecutiveLowBuffer = 0;
+    _currentUrl = url;
+    _currentChannelId = channelId;
+    _currentEpgChannelId = epgChannelId;
+    _currentTvgId = tvgId;
+    _currentChannelName = channelName;
+    _currentVanityName = vanityName;
     _tracksSub?.cancel();
+    _failoverCheckTimer?.cancel();
     await _ensureReady();
     await player.open(Media(url));
+    await _bufferManager.applyForStream(url, this);
     await player.setVolume(100.0);
+
+    // Reset and start buffer tracking for the new stream
+    bufferHistory.fillRange(0, 60, false);
+    bufferEventCount = 0;
+    bufferingSeconds = 0;
+    startBufferTracking();
+    _startFailoverMonitor();
   }
 
   /// Whether audio tracks are available on the current stream.
@@ -97,6 +150,7 @@ class PlayerService {
 
   /// Stop playback.
   Future<void> stop() async {
+    _bufferManager.stop();
     await player.stop();
   }
 
@@ -173,8 +227,91 @@ class PlayerService {
     return null;
   }
 
+  /// Current adaptive buffer manager for UI access.
+  AdaptiveBufferManager get bufferManager => _bufferManager;
+
+  /// Start tracking buffer events and accumulating buffering time.
+  void startBufferTracking() {
+    if (_trackingBuffering) return;
+    _trackingBuffering = true;
+
+    _bufferTrackSub?.cancel();
+    _bufferTrackSub = player.stream.buffering.listen((isBuffering) {
+      bufferHistory.removeAt(0);
+      bufferHistory.add(isBuffering);
+      if (isBuffering && !_isBuffering) bufferEventCount++;
+    });
+
+    _bufferTrackTimer?.cancel();
+    _bufferTrackTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (player.state.buffering) bufferingSeconds++;
+    });
+  }
+
+  /// Current stream URL for external reference.
+  String? get currentUrl => _currentUrl;
+
+  // ── Auto-failover monitor ──────────────────────────────────────────────
+
+  void _startFailoverMonitor() {
+    _failoverCheckTimer?.cancel();
+    _failoverCheckTimer = Timer.periodic(const Duration(seconds: 2), (_) async {
+      if (_alternatives == null || _currentUrl == null) return;
+
+      final raw = await getMpvProperty('demuxer-cache-duration');
+      final cacheSecs = double.tryParse(raw ?? '');
+      if (cacheSecs == null) return;
+
+      // Record health sample
+      _healthTracker?.recordBufferSample(_currentUrl!, cacheSecs);
+
+      if (cacheSecs < 1.0) {
+        _consecutiveLowBuffer++;
+        if (_consecutiveLowBuffer >= 3) {
+          // 6+ seconds of critically low buffer → failover
+          _healthTracker?.recordStall(_currentUrl!);
+          await _autoFailover();
+        }
+      } else {
+        _consecutiveLowBuffer = 0;
+      }
+    });
+  }
+
+  Future<void> _autoFailover() async {
+    if (_alternatives == null || _currentUrl == null) return;
+
+    final alts = _alternatives!.getAlternatives(
+      channelId: _currentChannelId ?? '',
+      epgChannelId: _currentEpgChannelId,
+      tvgId: _currentTvgId,
+      channelName: _currentChannelName,
+      vanityName: _currentVanityName,
+      excludeUrl: _currentUrl!,
+    );
+
+    if (alts.isEmpty) return;
+
+    final newUrl = alts.first;
+    _consecutiveLowBuffer = 0;
+
+    // Switch stream (keep channel metadata — it's the same content)
+    _failoverCheckTimer?.cancel();
+    _currentUrl = newUrl;
+    await player.open(Media(newUrl));
+    await _bufferManager.applyForStream(newUrl, this);
+    _startFailoverMonitor();
+
+    onFailover?.call('⚡ Switched stream');
+  }
+
   void dispose() {
+    _bufferManager.stop();
     _tracksSub?.cancel();
+    _bufferTrackSub?.cancel();
+    _bufferTrackTimer?.cancel();
+    _failoverCheckTimer?.cancel();
+    _healthTracker?.save();
     _player?.dispose();
   }
 }
@@ -182,6 +319,14 @@ class PlayerService {
 /// Riverpod provider for the player service (singleton).
 final playerServiceProvider = Provider<PlayerService>((ref) {
   final service = PlayerService();
+  // Inject failover services
+  try {
+    final alternatives = ref.read(streamAlternativesProvider);
+    final health = ref.read(streamHealthTrackerProvider);
+    service.configureFailover(alternatives, health);
+  } catch (_) {
+    // Services may not be available yet — failover will be disabled
+  }
   ref.onDispose(() => service.dispose());
   return service;
 });


### PR DESCRIPTION
## Changes

- **Auto-failover**: StreamAlternativesService indexes channels by EPG, tvgId, vanity name; PlayerService monitors buffer every 2s and auto-switches after 6s critical
- **Vanity name failover**: Channels sharing the same vanity name are treated as user-confirmed interchangeable — highest priority for failover
- **Call-sign aware EPG grouping**: Local affiliates (ABC WABC ≠ ABC WLS) require matching call signs; cable channels (ESPN, CNN) use EPG-only matching
- **Rename in fullscreen player**: Pencil icon in control bar opens rename dialog
- **Differentiated buffer tiers**: fast (60s readahead, no pause), normal (120s, 2s pause), aggressive (180s, 3s pause with initial pause)
- **EPG auto-mapper improvements**: Extract call signs from compound tvgIds like `abcwabc.us` and parenthesized names like `ABC 7 (WABC)`
- **Stream health tracking**: Per-stream scoring (stalls, buffer avg, TTFF) with persistence and time decay
- **Weather zipcode settings**: Geocoding dialog with auto-detect
- **Control bar hover fix**: Bar stays visible while hovering sparkline tooltips
- **Buffer sparkline fix**: Shows current value when < 2 data points