### PR TITLE
🐛 Never pause playback on empty buffer, show failover alts in debug

### DIFF
--- a/lib/features/player/adaptive_buffer.dart
+++ b/lib/features/player/adaptive_buffer.dart
@@ -21,16 +21,16 @@ class AdaptiveBufferManager {
   static const _prefsKey = 'adaptive_buffer_profiles';
 
   // Buffer tier definitions (mpv properties)
-  // All tiers share high maximums, but differ in pause behavior:
-  //   fast:       Never pause for buffer — instant channel switching
-  //   normal:     Brief pause if buffer critically empty
-  //   aggressive: Pause up to 3s to build buffer, more readahead
+  // All tiers: never pause playback on empty buffer — keep playing and let
+  // the stream recover naturally or trigger auto-failover instead.
+  // Tiers differ only in readahead aggressiveness.
   static const _tierConfig = <String, Map<String, String>>{
     'fast': {
       'cache': 'yes',
       'cache-secs': '180',
+      'cache-pause': 'no',
       'cache-pause-initial': 'no',
-      'cache-pause-wait': '1',
+      'cache-pause-wait': '0',
       'demuxer-max-bytes': '800M',
       'demuxer-max-back-bytes': '200M',
       'demuxer-readahead-secs': '60',
@@ -38,8 +38,9 @@ class AdaptiveBufferManager {
     'normal': {
       'cache': 'yes',
       'cache-secs': '180',
+      'cache-pause': 'no',
       'cache-pause-initial': 'no',
-      'cache-pause-wait': '2',
+      'cache-pause-wait': '0',
       'demuxer-max-bytes': '800M',
       'demuxer-max-back-bytes': '200M',
       'demuxer-readahead-secs': '120',
@@ -47,8 +48,9 @@ class AdaptiveBufferManager {
     'aggressive': {
       'cache': 'yes',
       'cache-secs': '180',
-      'cache-pause-initial': 'yes',
-      'cache-pause-wait': '3',
+      'cache-pause': 'no',
+      'cache-pause-initial': 'no',
+      'cache-pause-wait': '0',
       'demuxer-max-bytes': '800M',
       'demuxer-max-back-bytes': '200M',
       'demuxer-readahead-secs': '180',

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -12,6 +12,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../data/datasources/local/database.dart' as db;
+import '../../data/services/stream_alternatives_service.dart';
 import '../../features/providers/provider_manager.dart' show databaseProvider;
 import '../casting/cast_service.dart';
 import '../casting/cast_dialog.dart';
@@ -963,6 +964,17 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
     );
     final ps = ref.read(playerServiceProvider);
     final epgId = ch['epgId'] as String?;
-    ChannelDebugDialog.show(context, channel, ps, mappedEpgId: epgId);
+    final alts = ref.read(streamAlternativesProvider).getAlternativeDetails(
+      channelId: ch['id'] as String? ?? '',
+      epgChannelId: epgId,
+      tvgId: ch['tvgId'] as String?,
+      channelName: ch['name'] as String?,
+      vanityName: ch['vanityName'] as String?,
+      excludeUrl: ch['streamUrl'] as String? ?? '',
+    );
+    ChannelDebugDialog.show(context, channel, ps,
+        mappedEpgId: epgId,
+        originalName: ch['originalName'] as String? ?? ch['name'] as String?,
+        alternatives: alts);
   }
 }


### PR DESCRIPTION
- **cache-pause=no, cache-pause-wait=0** on all tiers — mpv never auto-pauses on empty buffer. Stream keeps playing; auto-failover handles recovery.
- Debug dialog now shows **original channel name** when vanity name is set
- Debug dialog shows **failover alternatives** list with match reason (vanity name/tvgId/EPG+call sign/name) and health score %
- Pencil icon in fullscreen player control bar for channel rename