### PR TITLE
✨ Failover group with provider badges and call sign matching

### DIFF
--- a/lib/features/channels/channels_screen.dart
+++ b/lib/features/channels/channels_screen.dart
@@ -357,6 +357,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         tvgId: _failoverSuggestion!.tvgId,
         channelName: _failoverSuggestion!.name,
         vanityName: _vanityNames[_failoverSuggestion!.id],
+        originalName: _failoverSuggestion!.tvgName,
       );
       setState(() {
         _previewChannel = _failoverSuggestion;
@@ -715,6 +716,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
       tvgId: channel.tvgId,
       channelName: channel.name,
       vanityName: _vanityNames[channel.id],
+      originalName: channel.tvgName,
     );
     setState(() {
       _selectedIndex = index;
@@ -737,6 +739,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
       tvgId: channel.tvgId,
       channelName: channel.name,
       vanityName: _vanityNames[channel.id],
+      originalName: channel.tvgName,
     );
     setState(() {
       _selectedIndex = swapTo;
@@ -827,6 +830,7 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         tvgId: channel.tvgId,
         channelName: channel.name,
         vanityName: _vanityNames[channel.id],
+        originalName: channel.tvgName,
         excludeUrl: channel.streamUrl,
       );
     } catch (_) {
@@ -973,7 +977,8 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         final alts = _getFailoverAlts(_previewChannel!);
         ChannelDebugDialog.show(context, _previewChannel!, ps,
             mappedEpgId: _getEpgId(_previewChannel!),
-            originalName: _previewChannel!.name,
+            originalName: _previewChannel!.tvgName ?? _previewChannel!.name,
+            currentProviderName: ref.read(streamAlternativesProvider).providerName(_previewChannel!.providerId),
             alternatives: alts);
       }
       return;
@@ -1533,7 +1538,9 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
                                       final ps = ref.read(playerServiceProvider);
                                       ChannelDebugDialog.show(context, _previewChannel!, ps,
                                           mappedEpgId: _getEpgId(_previewChannel!),
-                                          originalName: _previewChannel!.name);
+                                          originalName: _previewChannel!.tvgName ?? _previewChannel!.name,
+                                          currentProviderName: ref.read(streamAlternativesProvider).providerName(_previewChannel!.providerId),
+                                          alternatives: _getFailoverAlts(_previewChannel!));
                                     },
                                     icon: const Icon(Icons.info_outline, size: 16),
                                     padding: EdgeInsets.zero,
@@ -3388,7 +3395,10 @@ class _ChannelsScreenState extends ConsumerState<ChannelsScreen> {
         case 'debug':
           final ps = ref.read(playerServiceProvider);
           ChannelDebugDialog.show(context, channel, ps,
-              mappedEpgId: _getEpgId(channel), originalName: channel.name);
+              mappedEpgId: _getEpgId(channel),
+              originalName: channel.tvgName ?? channel.name,
+              currentProviderName: ref.read(streamAlternativesProvider).providerName(channel.providerId),
+              alternatives: _getFailoverAlts(channel));
       }
     });
   }

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -173,6 +173,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
         tvgId: widget.channels.isNotEmpty ? widget.channels[_channelIndex]['tvgId'] as String? : null,
         channelName: _currentChannelName,
         vanityName: widget.channels.isNotEmpty ? widget.channels[_channelIndex]['vanityName'] as String? : null,
+        originalName: widget.channels.isNotEmpty ? widget.channels[_channelIndex]['tvgName'] as String? : null,
       );
     }
 
@@ -945,36 +946,41 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen> {
   }
 
   void _showInfoDialog() {
-    // Build a db.Channel from current channel data for the debug dialog
     if (widget.channels.isEmpty) return;
-    final ch = widget.channels[_channelIndex];
-    final channel = db.Channel(
-      id: ch['id'] as String? ?? '',
-      providerId: ch['providerId'] as String? ?? '',
-      name: ch['name'] as String? ?? '',
-      groupTitle: ch['groupTitle'] as String? ?? '',
-      streamUrl: ch['streamUrl'] as String? ?? '',
-      streamType: ch['streamType'] as String? ?? 'live',
-      tvgId: ch['tvgId'] as String?,
-      tvgName: ch['tvgName'] as String?,
-      tvgLogo: ch['tvgLogo'] as String?,
-      favorite: false,
-      hidden: false,
-      sortOrder: 0,
-    );
-    final ps = ref.read(playerServiceProvider);
-    final epgId = ch['epgId'] as String?;
-    final alts = ref.read(streamAlternativesProvider).getAlternativeDetails(
-      channelId: ch['id'] as String? ?? '',
-      epgChannelId: epgId,
-      tvgId: ch['tvgId'] as String?,
-      channelName: ch['name'] as String?,
-      vanityName: ch['vanityName'] as String?,
-      excludeUrl: ch['streamUrl'] as String? ?? '',
-    );
-    ChannelDebugDialog.show(context, channel, ps,
-        mappedEpgId: epgId,
-        originalName: ch['originalName'] as String? ?? ch['name'] as String?,
-        alternatives: alts);
+    try {
+      final ch = widget.channels[_channelIndex];
+      final channel = db.Channel(
+        id: ch['id']?.toString() ?? '',
+        providerId: ch['providerId']?.toString() ?? '',
+        name: ch['name']?.toString() ?? '',
+        groupTitle: ch['groupTitle']?.toString() ?? '',
+        streamUrl: ch['streamUrl']?.toString() ?? '',
+        streamType: ch['streamType']?.toString() ?? 'live',
+        tvgId: ch['tvgId']?.toString(),
+        tvgName: ch['tvgName']?.toString(),
+        tvgLogo: ch['tvgLogo']?.toString(),
+        favorite: false,
+        hidden: false,
+        sortOrder: 0,
+      );
+      final ps = ref.read(playerServiceProvider);
+      final epgId = ch['epgId']?.toString();
+      final alts = ref.read(streamAlternativesProvider).getAlternativeDetails(
+        channelId: ch['id']?.toString() ?? '',
+        epgChannelId: epgId,
+        tvgId: ch['tvgId']?.toString(),
+        channelName: ch['name']?.toString(),
+        vanityName: ch['vanityName']?.toString(),
+        originalName: ch['tvgName']?.toString(),
+        excludeUrl: ch['streamUrl']?.toString() ?? '',
+      );
+      ChannelDebugDialog.show(context, channel, ps,
+          mappedEpgId: epgId,
+          originalName: ch['tvgName']?.toString() ?? ch['originalName']?.toString() ?? ch['name']?.toString(),
+          currentProviderName: ref.read(streamAlternativesProvider).providerName(ch['providerId']?.toString() ?? ''),
+          alternatives: alts);
+    } catch (e) {
+      debugPrint('Error showing info dialog: $e');
+    }
   }
 }

--- a/lib/features/player/player_service.dart
+++ b/lib/features/player/player_service.dart
@@ -37,6 +37,7 @@ class PlayerService {
   String? _currentTvgId;
   String? _currentChannelName;
   String? _currentVanityName;
+  String? _currentOriginalName;
   StreamAlternativesService? _alternatives;
   StreamHealthTracker? _healthTracker;
   Timer? _failoverCheckTimer;
@@ -115,6 +116,7 @@ class PlayerService {
     String? tvgId,
     String? channelName,
     String? vanityName,
+    String? originalName,
   }) async {
     _isBuffering = false;
     _bufferStartTime = null;
@@ -125,6 +127,7 @@ class PlayerService {
     _currentTvgId = tvgId;
     _currentChannelName = channelName;
     _currentVanityName = vanityName;
+    _currentOriginalName = originalName;
     _tracksSub?.cancel();
     _failoverCheckTimer?.cancel();
     await _ensureReady();
@@ -287,6 +290,7 @@ class PlayerService {
       tvgId: _currentTvgId,
       channelName: _currentChannelName,
       vanityName: _currentVanityName,
+      originalName: _currentOriginalName,
       excludeUrl: _currentUrl!,
     );
 


### PR DESCRIPTION
- Show current channel + alternatives in Failover Group section
- Provider name badge (PK, King, etc.) on each failover row  
- Fix call sign extraction to check both channelName and originalName
- Index tvgName for call sign matching across providers
- Add providerName field to AlternativeDetail
- Cache provider names from DB in StreamAlternativesService
- Harden null safety in player_screen info dialog
- Pass originalName through all play() and debug dialog calls