### PR TITLE
✨ Failover accept/reject UI with audio fix on stream switch

### DIFF
--- a/lib/features/player/player_service.dart
+++ b/lib/features/player/player_service.dart
@@ -304,6 +304,7 @@ class PlayerService {
     _currentUrl = newUrl;
     await player.open(Media(newUrl));
     await _bufferManager.applyForStream(newUrl, this);
+    await player.setVolume(100.0);
     _startFailoverMonitor();
 
     onFailover?.call('⚡ Switched stream');


### PR DESCRIPTION
- Green ✓ / red ✗ buttons on each failover alternative to accept or reject
- Save button persists decisions: accepted get same vanity name, rejected stored in SharedPreferences
- Reset button clears all rejections and re-discovers alternatives
- Dialog is now scrollable (ListView) with max 85% screen height — fixes overflow
- Auto-failover now sets volume to 100% after switching stream (fixes silent audio)
- Failover Group count reflects only accepted alternatives