### PR TITLE
🐛 Fix repeated macOS file access permission prompt

### DIFF
--- a/lib/data/datasources/local/database.dart
+++ b/lib/data/datasources/local/database.dart
@@ -415,9 +415,19 @@ class AppDatabase extends _$AppDatabase {
 
 LazyDatabase _openConnection() {
   return LazyDatabase(() async {
-    final dir = await getApplicationDocumentsDirectory();
+    final dir = await getApplicationSupportDirectory();
     final file = File(p.join(dir.path, 'clubtivi', 'clubtivi.db'));
     await file.parent.create(recursive: true);
+
+    // Migrate from old ~/Documents location if the new DB doesn't exist yet.
+    if (!await file.exists()) {
+      final oldDir = await getApplicationDocumentsDirectory();
+      final oldFile = File(p.join(oldDir.path, 'clubtivi', 'clubtivi.db'));
+      if (await oldFile.exists()) {
+        await oldFile.copy(file.path);
+      }
+    }
+
     return NativeDatabase.createInBackground(file);
   });
 }

--- a/lib/data/services/backup_service.dart
+++ b/lib/data/services/backup_service.dart
@@ -34,7 +34,7 @@ class BackupService {
     final archive = Archive();
 
     // 1. SQLite database
-    final dir = await getApplicationDocumentsDirectory();
+    final dir = await getApplicationSupportDirectory();
     final dbFile = File(p.join(dir.path, 'clubtivi', 'clubtivi.db'));
     if (await dbFile.exists()) {
       final bytes = await dbFile.readAsBytes();
@@ -102,7 +102,7 @@ class BackupService {
     // 2. Restore database
     final dbArchiveFile = archive.findFile('clubtivi.db');
     if (dbArchiveFile != null) {
-      final dir = await getApplicationDocumentsDirectory();
+      final dir = await getApplicationSupportDirectory();
       final dbPath = p.join(dir.path, 'clubtivi', 'clubtivi.db');
       await File(dbPath).parent.create(recursive: true);
       await File(dbPath).writeAsBytes(dbArchiveFile.content as List<int>);


### PR DESCRIPTION
Move database from ~/Documents to ~/Library/Application Support (no permission needed). Auto-migrates existing DB on first launch.