### PR TITLE
✨ Failover group UX: EPG, delete group, remove member

### DIFF
--- a/lib/data/datasources/local/database.dart
+++ b/lib/data/datasources/local/database.dart
@@ -435,6 +435,11 @@ class AppDatabase extends _$AppDatabase {
   Future<void> renameFailoverGroup(int groupId, String name) =>
       (update(failoverGroups)..where((t) => t.id.equals(groupId)))
           .write(FailoverGroupsCompanion(name: Value(name)));
+
+  Future<void> removeChannelFromFailoverGroup(int groupId, String channelId) =>
+      (delete(failoverGroupChannels)
+            ..where((t) => t.groupId.equals(groupId) & t.channelId.equals(channelId)))
+          .go();
 }
 
 LazyDatabase _openConnection() {


### PR DESCRIPTION
**Changes:**
- Show now-playing EPG text on failover group row (from first member channel)
- Right-click group row → bottom sheet with Play, Rename, Delete options
- Right-click expanded member → bottom sheet with Play or Remove from Group
- New `removeChannelFromFailoverGroup()` DB method
- Extracted `_reloadFailoverGroups()` for instant UI updates after any group mutation
- All group actions (create/rename/delete/remove member) now update instantly instead of full reload