### PR TITLE
✨ Add D-pad navigation to Smart Channels + optimize splash for TV

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -30,7 +30,7 @@ class ClubTiviTheme {
         centerTitle: false,
       ),
       // Focus highlight for D-pad / remote navigation
-      focusColor: _accent.withValues(alpha: 0.3),
+      focusColor: _accent.withValues(alpha: 0.45),
       hoverColor: _accent.withValues(alpha: 0.1),
       // ListTile focus/hover styling
       listTileTheme: ListTileThemeData(

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -311,7 +311,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         },
       },
       child: Focus(
-        autofocus: true,
+        autofocus: !Platform.isAndroid,
         child: Scaffold(
       appBar: AppBar(
         leading: IconButton(
@@ -1018,7 +1018,7 @@ class _ApiKeyCardState extends State<_ApiKeyCard> {
   @override
   void initState() {
     super.initState();
-    _expanded = !widget.isConfigured;
+    _expanded = Platform.isAndroid ? false : !widget.isConfigured;
   }
 
   @override
@@ -1073,58 +1073,66 @@ class _ApiKeyCardState extends State<_ApiKeyCard> {
             onTap: () => setState(() => _expanded = !_expanded),
           ),
           if (_expanded)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  TextFormField(
-                    controller: widget.controller,
-                    obscureText: true,
-                    decoration: InputDecoration(
-                      labelText: widget.tokenLabel,
-                      hintText: widget.tokenHint,
-                      prefixIcon: const Icon(Icons.vpn_key, size: 20),
-                      suffixIcon: _buildSuffixIcon(),
-                      border: const OutlineInputBorder(),
-                      isDense: true,
+            FocusTraversalGroup(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TextFormField(
+                      controller: widget.controller,
+                      obscureText: true,
+                      textInputAction: TextInputAction.done,
+                      onFieldSubmitted: (_) {
+                        if (widget.controller.text.trim().isNotEmpty) {
+                          widget.onSave();
+                        }
+                      },
+                      decoration: InputDecoration(
+                        labelText: widget.tokenLabel,
+                        hintText: widget.tokenHint,
+                        prefixIcon: const Icon(Icons.vpn_key, size: 20),
+                        suffixIcon: _buildSuffixIcon(),
+                        border: const OutlineInputBorder(),
+                        isDense: true,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: FilledButton.icon(
-                          onPressed: hasToken ? widget.onSave : null,
-                          icon: const Icon(Icons.save, size: 18),
-                          label: const Text('Save'),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: FilledButton.icon(
+                            onPressed: hasToken ? widget.onSave : null,
+                            icon: const Icon(Icons.save, size: 18),
+                            label: const Text('Save'),
+                          ),
                         ),
-                      ),
-                      const SizedBox(width: 8),
-                      OutlinedButton.icon(
-                        onPressed: hasToken && !widget.isVerifying
-                            ? widget.onVerify
-                            : null,
-                        icon: widget.isVerifying
-                            ? const SizedBox(
-                                width: 16, height: 16,
-                                child: CircularProgressIndicator(strokeWidth: 2),
-                              )
-                            : const Icon(Icons.verified_outlined, size: 18),
-                        label: const Text('Verify'),
-                      ),
-                      const SizedBox(width: 8),
-                      OutlinedButton.icon(
-                        onPressed: () {
-                          final url = Uri.parse(widget.tokenUrl);
-                          launchUrl(url, mode: LaunchMode.externalApplication);
-                        },
-                        icon: const Icon(Icons.open_in_new, size: 16),
-                        label: const Text('Get Key'),
-                      ),
-                    ],
-                  ),
-                ],
+                        const SizedBox(width: 8),
+                        OutlinedButton.icon(
+                          onPressed: hasToken && !widget.isVerifying
+                              ? widget.onVerify
+                              : null,
+                          icon: widget.isVerifying
+                              ? const SizedBox(
+                                  width: 16, height: 16,
+                                  child: CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : const Icon(Icons.verified_outlined, size: 18),
+                          label: const Text('Verify'),
+                        ),
+                        const SizedBox(width: 8),
+                        OutlinedButton.icon(
+                          onPressed: () {
+                            final url = Uri.parse(widget.tokenUrl);
+                            launchUrl(url, mode: LaunchMode.externalApplication);
+                          },
+                          icon: const Icon(Icons.open_in_new, size: 16),
+                          label: const Text('Get Key'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
         ],


### PR DESCRIPTION
## Smart Channel D-pad Navigation

Smart Channel (failover group) rows in both channel list and EPG guide were completely unreachable on Android TV — they used `InkWell`/`GestureDetector` without `Focus` wrappers, making them invisible to D-pad navigation.

### Channel List
- **Group rows**: Focus wrapper with key handlers
  - CENTER → play the Smart Channel
  - RIGHT → expand to show members
  - LEFT → collapse (or focus sidebar if already collapsed)
  - contextMenu/F5 → show group actions (delete, etc.)
- **Member rows**: Same Focus pattern
  - CENTER → play that specific member stream
  - LEFT → focus sidebar
  - contextMenu/F5 → show member actions (remove from group)
- Purple focus ring (tint + border) matches existing channel row style

### EPG Guide
- Same Focus + key handler pattern for group and member rows
- Focus highlight with purple tint and thicker left border

## Splash Screen Optimization

Budget Android TV devices (Fire Stick, Chromecast with Mali-400/PowerVR GPUs) struggle with the splash screen's GPU-heavy effects.

On `Platform.isAndroid`:
- Skip `CustomPaint` (radial glow painter + streaming waves painter)
- Don't create `_glowController` (eliminates continuous 2s animation loop)
- Replace `Shimmer` title with plain white text
- Reduce animation duration from 3.5s → 2s
- Auto-navigate to home screen still works identically

Desktop (macOS) retains all effects unchanged.